### PR TITLE
Added iter functions to data structures

### DIFF
--- a/src/data/macros.rs
+++ b/src/data/macros.rs
@@ -25,6 +25,13 @@ macro_rules! create_data_struct {
             held: Vec<$held>,
         }
 
+        impl $name {
+            /// Get the iterator from the `held` Vec without having to move/clone data
+            pub fn iter(&self) -> impl Iterator<Item = &$held> {
+                self.held.iter()
+            }
+        }
+
         #[async_trait]
         impl HyprData for $name {
             fn get() -> HResult<Self> {
@@ -65,10 +72,19 @@ macro_rules! create_data_struct {
         }
     };
 
-    (sing $name:ident,$kind:path,$held:ty,$c:literal) => {
+    (sing $name:ident,$kind:path,$held:ty,$c:literal $(, iter_item = $it_it:ty)*) => {
         #[doc = $c]
         #[derive(Debug)]
         pub struct $name($held);
+
+        impl $name {
+            $(
+                /// Get the iterator from the `held` Vec without having to move/clone data
+                pub fn iter(&self) -> impl Iterator<Item = $it_it> {
+                    self.0.iter()
+                }
+            )*
+        }
 
         #[async_trait]
         impl HyprData for $name {

--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -287,11 +287,19 @@ pub struct LayerDisplay {
     pub levels: HashMap<String, Vec<LayerClient>>,
 }
 
+impl LayerDisplay {
+    /// Returns an iterator over the levels map
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Vec<LayerClient>)> {
+        self.levels.iter()
+    }
+}
+
 create_data_struct!(
     sing Layers,
     DataCommands::Layers,
     HashMap<String, LayerDisplay>,
-    "This struct holds a hashmap of all current displays, and their layer surfaces"
+    "This struct holds a hashmap of all current displays, and their layer surfaces",
+    iter_item = (&String, &LayerDisplay)
 );
 
 /// This struct holds information about a mouse device


### PR DESCRIPTION
There's no need to move/clone data anymore if there's no reason to do so, I tested the code on my own application: https://github.com/tukanoidd/hyprr, it compiles and works like a charm
No breaking changes, macro functionality was just extended
I didn't add anything to the "p" variant because it didn't seem to be used anywhere.