### PR TITLE
fix: read all Hyprland socket data returned

### DIFF
--- a/src/shared.rs
+++ b/src/shared.rs
@@ -180,20 +180,20 @@ pub(crate) async fn write_to_socket(path: String, content: &[u8]) -> HResult<Str
 
     stream.write_all(content).await?;
 
-    let mut response = String::new();
+    let mut response = vec![];
 
     const BUF_SIZE: usize = 8192;
     let mut buf = [0; BUF_SIZE];
     loop {
         let num_read = stream.read(&mut buf).await?;
         let buf = &buf[..num_read];
-        response += &String::from_utf8(buf.to_vec())?;
+        response.append(&mut buf.to_vec());
         if num_read == 0 || num_read != BUF_SIZE {
             break;
         }
     }
 
-    Ok(response)
+    Ok(String::from_utf8(response)?)
 }
 
 /// This pub(crate) function is used to write a value to a socket and to get the response
@@ -204,20 +204,20 @@ pub(crate) fn write_to_socket_sync(path: String, content: &[u8]) -> HResult<Stri
 
     stream.write_all(content)?;
 
-    let mut response = String::new();
+    let mut response = vec![];
 
     const BUF_SIZE: usize = 8192;
     let mut buf = [0; BUF_SIZE];
     loop {
         let num_read = stream.read(&mut buf)?;
         let buf = &buf[..num_read];
-        response += &String::from_utf8(buf.to_vec())?;
+        response.append(&mut buf.to_vec());
         if num_read == 0 || num_read != BUF_SIZE {
             break;
         }
     }
 
-    Ok(response)
+    Ok(String::from_utf8(response)?)
 }
 
 /// This pub(crate) enum holds the different sockets that Hyprland has


### PR DESCRIPTION
Without this fix, when I got a lot of windows open / clients, this lead to a truncated JSON.

fix: https://github.com/cyrinux/hyprland-autoname-workspaces/issues/8