### PR TITLE
fix: client struct use more signed integer

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -223,7 +223,7 @@ pub struct Client {
     /// The window title
     pub title: String,
     /// The process Id of the client
-    pub pid: u32,
+    pub pid: i32,
     /// Is this window running under XWayland?
     pub xwayland: bool,
     /// Is this window pinned?

--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -217,7 +217,7 @@ pub struct Client {
     #[serde(rename = "fullscreenMode")]
     pub fullscreen_mode: u8,
     /// The monitor the window is on
-    pub monitor: u8,
+    pub monitor: i8,
     /// The window class
     pub class: String,
     /// The window title

--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -215,7 +215,7 @@ pub struct Client {
     pub fullscreen: bool,
     /// What type of fullscreen?
     #[serde(rename = "fullscreenMode")]
-    pub fullscreen_mode: u8,
+    pub fullscreen_mode: i8,
     /// The monitor the window is on
     pub monitor: i8,
     /// The window class


### PR DESCRIPTION
It Looks like in recent hyprland, client struct change. Some data are now a i8. 
fix: https://github.com/cyrinux/hyprland-autoname-workspaces/issues/17