### PR TITLE
fix: client size u16 to i16

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -210,7 +210,7 @@ pub struct Client {
     /// The window location
     pub at: (i16, i16),
     /// The window size
-    pub size: (u16, u16),
+    pub size: (i16, i16),
     /// The workspace its on
     pub workspace: WorkspaceBasic,
     /// Is this window floating?
@@ -277,9 +277,9 @@ pub struct LayerClient {
     /// The layer's y position
     pub y: i32,
     /// The layer's width
-    pub w: u16,
+    pub w: i16,
     /// The layer's height
-    pub h: u16,
+    pub h: i16,
     /// The layer's namespace
     pub namespace: String,
 }


### PR DESCRIPTION
Fix crash in dwindle mode https://github.com/cyrinux/hyprland-autoname-workspaces/issues/37

We have maybe more u16 and u32 to convert like this but I'm shy to transform them all...

Can you please make a release then 🙏🏻 