### PR TITLE
Fix parsing error when swallowing is active

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -231,7 +231,7 @@ pub struct Client {
     /// Group members
     pub grouped: Vec<Box<Address>>,
     /// The swallowed window
-    pub swallowing: Option<Box<Self>>,
+    pub swallowing: Option<Box<Address>>,
 }
 
 /// This enum holds the information for the active window


### PR DESCRIPTION
This PR contains a fix for the following bug: When retrieving the active window, parsing fails with

```
SerdeError(
    Error("data did not match any variant of untagged enum Aux", line: 0, column: 0),
)
```

Here is an example of the data that triggers this error:

```
{
    "address": "0x898d4ec0",
    "mapped": true,
    "hidden": false,
    "at": [13, 13],
    "size": [939, 497],
    "workspace": {
        "id": 1,
        "name": "1"
    },
    "floating": false,
    "monitor": 0,
    "class": "org.gnome.SoundRecorder",
    "title": "Tonaufzeichner",
    "initialClass": "org.gnome.SoundRecorder",
    "initialTitle": "Tonaufzeichner",
    "pid": 328198,
    "xwayland": false,
    "pinned": false,
    "fullscreen": false,
    "fullscreenMode": 0,
    "fakeFullscreen": false,
    "grouped": [],
    "swallowing": "0x898b4540"
}
```

Given that the field `swallowing` does not contain a `Client` object but an address, my best guess is that the field `pub swallowing: Option<Box<Self>>` should be changed to `pub swallowing: Option<Box<Address>>`.