### PR TITLE
Fix hyprctl notify color issue

### DIFF
--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -183,7 +183,7 @@ pub mod notify {
         Ok = 5,
     }
     /// Creates a notification with Hyprland
-    pub fn call(icon: Icon, time: Duration, color: Color, msg: String) -> crate::Result<()> {
+    pub fn call(icon: Icon, time: Duration, color: NColor, msg: String) -> crate::Result<()> {
         write_to_socket_sync(
             get_socket_path(SocketType::Command),
             command!(
@@ -199,7 +199,7 @@ pub mod notify {
     pub async fn call_async(
         icon: Icon,
         time: Duration,
-        color: Color,
+        color: NColor,
         msg: String,
     ) -> crate::Result<()> {
         write_to_socket(
@@ -214,6 +214,19 @@ pub mod notify {
         .await?;
         Ok(())
     }
+}
+
+#[derive(MDisplay, Constructor)]
+#[display(fmt = "rgba({:02x}{:02x}{:02x}{:02x})", "_0", "_1", "_2", "_3")]
+pub struct NColorRgba(u8, u8, u8, u8);
+
+#[derive(MDisplay, Constructor)]
+#[display(fmt = "rgb({:02x}{:02x}{:02x})", "_0", "_1", "_2")]
+pub struct NColorRgb(u8, u8, u8);
+
+pub enum NColor {
+    Rgb(NColorRgb),
+    Rgba(NColorRgba)
 }
 
 /// A 8-bit color with a alpha channel


### PR DESCRIPTION
hyprctl`s notify service has a different color expression logic. Colors can be Rgb or Rgba and the value of them has to be written in hex format. former system wrote colors as like as this: rgb(25, 255, 100). however, the correct form has to be like this: rgb(ff,e5,aa).