### PR TITLE
Remove reference to RegexError::__Nonexhaustive

### DIFF
--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -641,7 +641,7 @@ fn check_for_regex_error(val: Result<Regex, RegexError>) -> Regex {
         Err(RegexError::CompiledTooBig(size)) => {
             panic!("The compiled regex size is too big ({size})")
         }
-        Err(RegexError::__Nonexhaustive) => unreachable!(),
+        Err(_) => unreachable!(),
     }
 }
 
@@ -652,7 +652,7 @@ fn check_for_regex_set_error(val: Result<RegexSet, RegexError>) -> RegexSet {
         Err(RegexError::CompiledTooBig(size)) => {
             panic!("The compiled regex size is too big ({size})")
         }
-        Err(RegexError::__Nonexhaustive) => unreachable!(),
+        Err(_) => unreachable!(),
     }
 }
 


### PR DESCRIPTION
Since Regex [updated](https://github.com/rust-lang/regex/commit/ff27ce08bcc7957dbe3a4ada5cf0eb9b1d80ba13#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35e) their code for error we need to update the code.
