### PR TITLE
fix: make class capture group lazy

### DIFF
--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -698,7 +698,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
             r"createworkspace>>(?P<workspace>.*)",
             r"moveworkspace>>(?P<workspace>.*),(?P<monitor>.*)",
             r"focusedmon>>(?P<monitor>.*),(?P<workspace>.*)",
-            r"activewindow>>(?P<class>.*),(?P<title>.*)",
+            r"activewindow>>(?P<class>.*?),(?P<title>.*)",
             r"activewindowv2>>(?P<address>.*)",
             r"fullscreen>>(?P<state>0|1)",
             r"monitorremoved>>(?P<monitor>.*)",


### PR DESCRIPTION
Fixes #65

With this change, the examples I mention in that issue are now:
```
Some(
    WindowEventData {
        window_class: "firefox",
        window_title: "GrapheneOS: first impressions, stumbling blocks, and opinions - YouTube — M
ozilla Firefox",
        window_address: Address(
            "597b290",
        ),
    },
)
```
and
```
Some(
    WindowEventData {
        window_class: "firefox",
        window_title: "hyprland-community/hyprland-rs: An unofficial rust wrapper for hyprland's I
PC [maintainers=@yavko,@cyrinux] — Mozilla Firefox",
        window_address: Address(
            "597b290",
        ),
    },
)
```