### PR TITLE
fix: window address string formatting

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -35,7 +35,7 @@ pub enum WindowIdentifier<'a> {
 impl std::fmt::Display for WindowIdentifier<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let out = match self {
-            WindowIdentifier::Address(addr) => format!("address:{addr}"),
+            WindowIdentifier::Address(addr) => format!("address:0x{addr}"),
             WindowIdentifier::ProcessId(id) => format!("pid:{id}"),
             WindowIdentifier::ClassRegularExpression(regex) => regex.to_string(),
             WindowIdentifier::Title(title) => format!("title:{title}"),


### PR DESCRIPTION
Fixes #82 

hyprctl expects window addresses to be formatted as `0xDEADBEEF` instead of simply `DEADBEEF`.