### PR TITLE
fix: make address parsing consistent between events and data commands

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -35,7 +35,7 @@ pub enum WindowIdentifier<'a> {
 impl std::fmt::Display for WindowIdentifier<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let out = match self {
-            WindowIdentifier::Address(addr) => format!("address:0x{addr}"),
+            WindowIdentifier::Address(addr) => format!("address:{addr}"),
             WindowIdentifier::ProcessId(id) => format!("pid:{id}"),
             WindowIdentifier::ClassRegularExpression(regex) => regex.to_string(),
             WindowIdentifier::Title(title) => format!("title:{title}"),

--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -828,7 +828,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 }
             }
             ParsedEventType::ActiveWindowChangedV2 => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 if addr != "," {
                     events.push(Event::ActiveWindowChangedV2(Some(Address::new(addr))));
                 } else {
@@ -848,7 +848,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 events.push(Event::MonitorAdded(monitor.to_string()));
             }
             ParsedEventType::WindowOpened => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 let workspace = &captures["workspace"];
                 let class = &captures["class"];
                 let title = &captures["title"];
@@ -860,11 +860,11 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 }));
             }
             ParsedEventType::WindowClosed => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 events.push(Event::WindowClosed(Address::new(addr)));
             }
             ParsedEventType::WindowMoved => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 let work = &captures["workspace"];
                 events.push(Event::WindowMoved(WindowMoveEvent {
                     window_address: Address::new(addr),
@@ -892,7 +892,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 events.push(Event::LayerClosed(namespace.to_string()));
             }
             ParsedEventType::FloatStateChanged => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 let state = &captures["floatstate"] == "0"; // FIXME: does 0 mean it's floating?
                 events.push(Event::FloatStateChanged(WindowFloatEventData {
                     window_address: Address::new(addr),
@@ -900,7 +900,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 }));
             }
             ParsedEventType::Minimize => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 let state = &captures["state"] == "1";
                 events.push(Event::Minimize(MinimizeEventData {
                     window_address: Address::new(addr),
@@ -916,11 +916,11 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 }));
             }
             ParsedEventType::UrgentStateChanged => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 events.push(Event::UrgentStateChanged(Address::new(addr)));
             }
             ParsedEventType::WindowTitleChanged => {
-                let addr = &captures["address"];
+                let addr = format_event_addr(&captures["address"]);
                 events.push(Event::WindowTitleChanged(Address::new(addr)));
             }
             ParsedEventType::Unknown => {
@@ -957,4 +957,8 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
     }
 
     Ok(events)
+}
+
+fn format_event_addr(addr: &str) -> String {
+    format!("0x{addr}")
 }


### PR DESCRIPTION
#85 actually created issues with data returned from data commands.

The issue stems from the fact that data commands are calling hyprctl with the `--json` flag enabled. hyprctl returns addresses formatted as `0xDEADBEEF` from JSON, but does not do the same with regular output.

Addresses in events are returned as `DEADBEEF` instead, so this causes inconsistencies in the data when it comes from data commands and when it comes from events.

This PR addresses this issue by sticking with the `0xDEADBEEF` format, as that's the format dispatchers are expecting for window addresses. In every event listener where we are parsing window addresses, I simply prepended the matched address with `0x` in a helper function.