### PR TITLE
add main to struct Keyboard

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -338,6 +338,8 @@ pub struct Keyboard {
     pub options: String,
     /// The keyboard's active keymap
     pub active_keymap: String,
+    /// The keyboard's primary status
+    pub main: bool,
 }
 
 /// A enum that holds the types of tablets


### PR DESCRIPTION
Useful for performing keyboard layout changes programmatically, for example. 

See https://github.com/hyprwm/Hyprland/blob/4a4e13f8acedd2dc44236deed13fd47096cbe508/src/debug/HyprCtl.cpp#L448