### PR TITLE
Add WorkspaceIdentifier(WithSpecial) variant for `r` prefix

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -169,6 +169,8 @@ pub enum WorkspaceIdentifierWithSpecial<'a> {
     Relative(i32),
     /// The workspace on the monitor relative to the current workspace
     RelativeMonitor(i32),
+    /// The workspace on the monitor relative to the current workspace, including empty workspaces
+    RelativeMonitorIncludingEmpty(i32),
     /// The open workspace relative to the current workspace
     RelativeOpen(i32),
     /// The previous Workspace
@@ -189,6 +191,7 @@ impl std::fmt::Display for WorkspaceIdentifierWithSpecial<'_> {
             Name(name) => format!("name:{name}"),
             Relative(int) => format_relative(*int, ""),
             RelativeMonitor(int) => format_relative(*int, "m"),
+            RelativeMonitorIncludingEmpty(int) => format_relative(*int, "r"),
             RelativeOpen(int) => format_relative(*int, "e"),
             Previous => "previous".to_string(),
             Empty => "empty".to_string(),
@@ -211,6 +214,8 @@ pub enum WorkspaceIdentifier<'a> {
     Relative(i32),
     /// The workspace on the monitor relative to the current workspace
     RelativeMonitor(i32),
+    /// The workspace on the monitor relative to the current workspace, including empty workspaces
+    RelativeMonitorIncludingEmpty(i32),
     /// The open workspace relative to the current workspace
     RelativeOpen(i32),
     /// The previous Workspace
@@ -229,6 +234,7 @@ impl std::fmt::Display for WorkspaceIdentifier<'_> {
             Name(name) => format!("name:{name}"),
             Relative(int) => format_relative(*int, ""),
             RelativeMonitor(int) => format_relative(*int, "m"),
+            RelativeMonitorIncludingEmpty(int) => format_relative(*int, "r"),
             RelativeOpen(int) => format_relative(*int, "e"),
             Previous => "previous".to_string(),
             Empty => "empty".to_string(),

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -167,7 +167,7 @@ pub enum WorkspaceIdentifierWithSpecial<'a> {
     Id(WorkspaceId),
     /// The workspace relative to the current workspace
     Relative(i32),
-    /// The workspace on the monitor relative to the current monitor
+    /// The workspace on the monitor relative to the current workspace
     RelativeMonitor(i32),
     /// The open workspace relative to the current workspace
     RelativeOpen(i32),
@@ -209,7 +209,7 @@ pub enum WorkspaceIdentifier<'a> {
     Id(WorkspaceId),
     /// The workspace relative to the current workspace
     Relative(i32),
-    /// The workspace on the monitor relative to the current monitor
+    /// The workspace on the monitor relative to the current workspace
     RelativeMonitor(i32),
     /// The open workspace relative to the current workspace
     RelativeOpen(i32),


### PR DESCRIPTION
This PR:

- adds a `RelativeMonitorIncludingEmpty` variant for `WorkspaceIdentifier(WithSpecial)`, which corresponds to the relative workspace address format with the `r` prefix

https://wiki.hyprland.org/Configuring/Dispatchers/#workspaces

![20240127_16h37m50s_grim](https://github.com/hyprland-community/hyprland-rs/assets/39011611/eea525a8-4a7e-43d1-a5c6-22395756e61a)

- fixes the doc comment for the `RelativeMonitor` variant
