### PR TITLE
Add monitor id to workspaces

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -164,6 +164,9 @@ pub struct Workspace {
     pub name: String,
     /// The monitor the workspace is on
     pub monitor: String,
+    /// The monitor id the workspace is on
+    #[serde(rename = "monitorID")]
+    pub monitor_id: MonitorId,
     /// The amount of windows in the workspace
     pub windows: u16,
     /// A bool that shows if there is a fullscreen window in the workspace

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,4 +67,3 @@ pub(crate) mod unix_async {
 
 /// This type provides the result type used everywhere in Hyprland-rs
 pub type Result<T> = std::result::Result<T, shared::HyprError>;
-

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -116,6 +116,10 @@ pub trait HyprDataVec<T>: HyprData {
 /// > its a type because it might change at some point
 pub type WorkspaceId = i32;
 
+/// This type provides the id used to identify monitors
+/// > its a type because it might change at some point
+pub type MonitorId = u8;
+
 fn ser_spec_opt(opt: &Option<String>) -> String {
     match opt {
         Some(name) => format!("special:{name}"),
@@ -274,7 +278,6 @@ pub(crate) fn get_socket_path(socket_type: SocketType) -> String {
 
     format!("/tmp/hypr/{hypr_instance_sig}/{socket_name}")
 }
-
 
 /// Creates a `CommandContent` instance with the given flag and formatted data.
 ///


### PR DESCRIPTION
Add the `monitorID` field to `Workspaces` since it's provided by hyprctl. 

There's also a deleted line in lib.rs which was edited by `cargo fmt`