### PR TITLE
Use type MonitorId everywhere instead of u8, i128

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -94,7 +94,7 @@ pub enum Transforms {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Monitor {
     /// The monitor id
-    pub id: i128,
+    pub id: MonitorId,
     /// The monitor's name
     pub name: String,
     /// The monitor's description
@@ -220,7 +220,7 @@ pub struct Client {
     #[serde(rename = "fullscreenMode")]
     pub fullscreen_mode: i8,
     /// The monitor id the window is on
-    pub monitor: i128,
+    pub monitor: MonitorId,
     /// The initial window class
     #[serde(rename = "initialClass")]
     pub initial_class: String,

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -117,7 +117,7 @@ pub enum MonitorIdentifier<'a> {
     /// The monitor that is to the specified direction of the active one
     Direction(Direction),
     /// The monitor id
-    Id(u8),
+    Id(MonitorId),
     /// The monitor name
     Name(&'a str),
     /// The current monitor

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -118,7 +118,7 @@ pub type WorkspaceId = i32;
 
 /// This type provides the id used to identify monitors
 /// > its a type because it might change at some point
-pub type MonitorId = u8;
+pub type MonitorId = i128;
 
 fn ser_spec_opt(opt: &Option<String>) -> String {
     match opt {


### PR DESCRIPTION
The id in the Monitor struct is currently i128, and the monitor field inside client is also i128. [Discussed in this Issue](https://github.com/hyprland-community/hyprland-rs/issues/124).