### PR TITLE
fix: modified logic to_remove indices

### DIFF
--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -68,8 +68,8 @@ pub(crate) trait HasExecutor {
                     break;
                 }
             }
-            for index in to_remove {
-                abuf.remove(index);
+            for index in to_remove.into_iter().rev() {
+                abuf.swap_remove(index);
             }
         } else if let Event::ActiveWindowChangedV2(data) = event {
             let mut to_remove = vec![];
@@ -83,8 +83,8 @@ pub(crate) trait HasExecutor {
                     break;
                 }
             }
-            for index in to_remove {
-                abuf.remove(index);
+            for index in to_remove.into_iter().rev() {
+                abuf.swap_remove(index);
             }
         } else {
             self.event_executor(event)?;
@@ -121,8 +121,8 @@ pub(crate) trait HasAsyncExecutor {
                     break;
                 }
             }
-            for index in to_remove {
-                abuf.remove(index);
+            for index in to_remove.into_iter().rev() {
+                abuf.swap_remove(index);
             }
         } else if let Event::ActiveWindowChangedV2(data) = event {
             let mut to_remove = vec![];
@@ -136,8 +136,8 @@ pub(crate) trait HasAsyncExecutor {
                     break;
                 }
             }
-            for index in to_remove {
-                abuf.remove(index);
+            for index in to_remove.into_iter().rev() {
+                abuf.swap_remove(index);
             }
         } else {
             self.event_executor_async(event).await?;


### PR DESCRIPTION
I found a bug, which happens when the `abuf` contains more than one element and the `to_remove` vector also has more than one index. When deletes first element, the other elements on the right shifts to left, so it will be cause of wrong deletion of element from abuf.

I use `swap_remove`, because the order of elements in `abuf` is not important as far as I know. So the deletion of element will be completed in `O(1)` time (i.e. constant time).