### PR TITLE
feat: added a bunch iterators for data structs

### DIFF
--- a/src/data/macros.rs
+++ b/src/data/macros.rs
@@ -17,19 +17,25 @@ macro_rules! impl_on {
 }
 
 macro_rules! create_data_struct {
-    (vec $name:ident,$kind:path,$held:ty,$c:literal) => {
-        #[doc = $c]
+    (
+        vector,
+        name: $name:ident,
+        command: $cmd_kind:path,
+        holding_type: $holding_type:ty, 
+        doc: $doc:literal
+    ) => {
+        #[doc = $doc]
         #[derive(Debug, Clone)]
-        pub struct $name(Vec<$held>);
+        pub struct $name(Vec<$holding_type>);
 
         impl $name {
             /// Get the iterator by references of monitors.
-            pub fn iter(&self) -> std::slice::Iter<$held> {
+            pub fn iter(&self) -> std::slice::Iter<$holding_type> {
                 self.0.iter()
             }
 
             /// Get the iterator by mutable references of monitors.
-            pub fn iter_mut(&mut self) -> std::slice::IterMut<$held> {
+            pub fn iter_mut(&mut self) -> std::slice::IterMut<$holding_type> {
                 self.0.iter_mut()
             }
         }
@@ -37,21 +43,21 @@ macro_rules! create_data_struct {
         #[async_trait]
         impl HyprData for $name {
             fn get() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd($kind);
-                let deserialized: Vec<$held> = serde_json::from_str(&data)?;
+                let data = call_hyprctl_data_cmd($cmd_kind);
+                let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }
             async fn get_async() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd_async($kind).await;
-                let deserialized: Vec<$held> = serde_json::from_str(&data)?;
+                let data = call_hyprctl_data_cmd_async($cmd_kind).await;
+                let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }
         }
 
         impl IntoIterator for $name {
-            type Item = $held;
+            type Item = $holding_type;
 
-            type IntoIter = std::vec::IntoIter<$held>;
+            type IntoIter = std::vec::IntoIter<$holding_type>;
 
             fn into_iter(self) -> Self::IntoIter {
                 self.0.into_iter()
@@ -59,8 +65,8 @@ macro_rules! create_data_struct {
         }
 
         impl<'a> IntoIterator for &'a $name {
-            type Item = &'a $held;
-            type IntoIter = std::slice::Iter<'a, $held>;
+            type Item = &'a $holding_type;
+            type IntoIter = std::slice::Iter<'a, $holding_type>;
 
             fn into_iter(self) -> Self::IntoIter {
                 self.0.iter()
@@ -68,16 +74,16 @@ macro_rules! create_data_struct {
         }
 
         impl<'a> IntoIterator for &'a mut $name {
-            type Item = &'a mut $held;
-            type IntoIter = std::slice::IterMut<'a, $held>;
+            type Item = &'a mut $holding_type;
+            type IntoIter = std::slice::IterMut<'a, $holding_type>;
 
             fn into_iter(self) -> Self::IntoIter {
                 self.0.iter_mut()
             }
         }
 
-        impl HyprDataVec<$held> for $name {
-            fn to_vec(self) -> Vec<$held> {
+        impl HyprDataVec<$holding_type> for $name {
+            fn to_vec(self) -> Vec<$holding_type> {
                 self.0
             }
         }

--- a/src/data/macros.rs
+++ b/src/data/macros.rs
@@ -83,30 +83,29 @@ macro_rules! create_data_struct {
         }
     };
 
-    (sing $name:ident,$kind:path,$held:ty,$c:literal $(, iter_item = $it_it:ty)*) => {
-        #[doc = $c]
+    (
+        table,
+        name: $name:ident,
+        command: $cmd_kind:path,
+        key: $key:ty,
+        value: $value:ty,
+        doc: $doc:literal
+    ) => {
+        #[doc = $doc]
         #[derive(Debug)]
-        pub struct $name($held);
-
-        impl $name {
-            $(
-                /// Get the iterator from the `held` Vec without having to move/clone data
-                pub fn iter(&self) -> impl Iterator<Item = $it_it> {
-                    self.0.iter()
-                }
-            )*
-        }
+        pub struct $name(HashMap<$key, $value>);
 
         #[async_trait]
         impl HyprData for $name {
             fn get() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd($kind);
-                let deserialized: $held = serde_json::from_str(&data)?;
+                let data = call_hyprctl_data_cmd($cmd_kind);
+                let deserialized: HashMap<$key, $value> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }
+
             async fn get_async() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd_async($kind).await;
-                let deserialized: $held = serde_json::from_str(&data)?;
+                let data = call_hyprctl_data_cmd_async($cmd_kind).await;
+                let deserialized: HashMap<$key, $value> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }
         }

--- a/src/data/macros.rs
+++ b/src/data/macros.rs
@@ -24,15 +24,17 @@ macro_rules! implement_iterators {
         holding_type: $holding_type:ty, 
     ) => {
         impl $name {
-            /// Get the iterator by references of monitors.
-            pub fn iter(&self) -> std::slice::Iter<$holding_type> {
-                self.0.iter()
-            }
+            paste!(
+                #[doc = "Creates the iterator by references of `" $name "`."]
+                pub fn iter(&self) -> std::slice::Iter<$holding_type> {
+                    self.0.iter()
+                }
 
-            /// Get the iterator by mutable references of monitors.
-            pub fn iter_mut(&mut self) -> std::slice::IterMut<$holding_type> {
-                self.0.iter_mut()
-            }
+                #[doc = "Creates the iterator by mutable references of " $name "`."]
+                pub fn iter_mut(&mut self) -> std::slice::IterMut<$holding_type> {
+                    self.0.iter_mut()
+                }
+            );
         }
 
         impl IntoIterator for $name {
@@ -72,21 +74,27 @@ macro_rules! implement_iterators {
         value: $value:ty,
     ) => {
         impl $name {
-            pub fn iter(&self) -> std::collections::hash_map::Iter<$key, $value> {
-                self.$iterated_field.iter()
-            }
+            paste!(
+                #[doc = "Creates the iterator of map by references of " $name]
+                pub fn iter(&self) -> std::collections::hash_map::Iter<$key, $value> {
+                    self.$iterated_field.iter()
+                }
 
-            pub fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<$key, $value> {
-                self.$iterated_field.iter_mut()
-            }
+                #[doc = "Creates the iterator of map by mutable references of `" $name "`."]
+                pub fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<$key, $value> {
+                    self.$iterated_field.iter_mut()
+                }
 
-            pub fn into_keys(self) -> std::collections::hash_map::IntoKeys<$key, $value> {
-                self.$iterated_field.into_keys()
-            }
+                #[doc = "Creates the consuming iterator by keys with type `" $key "` of `" $name "`."]
+                pub fn into_keys(self) -> std::collections::hash_map::IntoKeys<$key, $value> {
+                    self.$iterated_field.into_keys()
+                }
 
-            pub fn into_values(self) -> std::collections::hash_map::IntoValues<$key, $value> {
-                self.$iterated_field.into_values()
-            }
+                #[doc = "Creates the consuming iterator by values of `" $name "`."]
+                pub fn into_values(self) -> std::collections::hash_map::IntoValues<$key, $value> {
+                    self.$iterated_field.into_values()
+                }
+            );
         }
 
         impl IntoIterator for $name {

--- a/src/data/macros.rs
+++ b/src/data/macros.rs
@@ -16,18 +16,13 @@ macro_rules! impl_on {
     };
 }
 
-macro_rules! create_data_struct {
+macro_rules! implement_iterators {
     (
         vector,
         name: $name:ident,
-        command: $cmd_kind:path,
+        iterated_field: $iterated_field:tt,
         holding_type: $holding_type:ty, 
-        doc: $doc:literal
     ) => {
-        #[doc = $doc]
-        #[derive(Debug, Clone)]
-        pub struct $name(Vec<$holding_type>);
-
         impl $name {
             /// Get the iterator by references of monitors.
             pub fn iter(&self) -> std::slice::Iter<$holding_type> {
@@ -37,20 +32,6 @@ macro_rules! create_data_struct {
             /// Get the iterator by mutable references of monitors.
             pub fn iter_mut(&mut self) -> std::slice::IterMut<$holding_type> {
                 self.0.iter_mut()
-            }
-        }
-
-        #[async_trait]
-        impl HyprData for $name {
-            fn get() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd($cmd_kind);
-                let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
-                Ok(Self(deserialized))
-            }
-            async fn get_async() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd_async($cmd_kind).await;
-                let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
-                Ok(Self(deserialized))
             }
         }
 
@@ -81,6 +62,94 @@ macro_rules! create_data_struct {
                 self.0.iter_mut()
             }
         }
+    };
+
+    (
+        table,
+        name: $name:ident,
+        iterated_field: $iterated_field:tt,
+        key: $key:ty,
+        value: $value:ty,
+    ) => {
+        impl $name {
+            pub fn iter(&self) -> std::collections::hash_map::Iter<$key, $value> {
+                self.$iterated_field.iter()
+            }
+
+            pub fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<$key, $value> {
+                self.$iterated_field.iter_mut()
+            }
+
+            pub fn into_keys(self) -> std::collections::hash_map::IntoKeys<$key, $value> {
+                self.$iterated_field.into_keys()
+            }
+
+            pub fn into_values(self) -> std::collections::hash_map::IntoValues<$key, $value> {
+                self.$iterated_field.into_values()
+            }
+        }
+
+        impl IntoIterator for $name {
+            type Item = ($key, $value);
+            type IntoIter = std::collections::hash_map::IntoIter<$key, $value>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.$iterated_field.into_iter()
+            }
+        }
+
+        impl<'a> IntoIterator for &'a $name {
+            type Item = (&'a $key, &'a $value);
+            type IntoIter = std::collections::hash_map::Iter<'a, $key, $value>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.$iterated_field.iter()
+            }
+        }
+
+        impl<'a> IntoIterator for &'a mut $name {
+            type Item = (&'a $key, &'a mut $value);
+            type IntoIter = std::collections::hash_map::IterMut<'a, $key, $value>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.$iterated_field.iter_mut()
+            }
+        }
+    }
+}
+
+macro_rules! create_data_struct {
+    (
+        vector,
+        name: $name:ident,
+        command: $cmd_kind:path,
+        holding_type: $holding_type:ty, 
+        doc: $doc:literal
+    ) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone)]
+        pub struct $name(Vec<$holding_type>);
+
+        implement_iterators!(
+            vector,
+            name: $name,
+            iterated_field: 0,
+            holding_type: $holding_type,
+        );
+
+        #[async_trait]
+        impl HyprData for $name {
+            fn get() -> $crate::Result<Self> {
+                let data = call_hyprctl_data_cmd($cmd_kind);
+                let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
+                Ok(Self(deserialized))
+            }
+            async fn get_async() -> $crate::Result<Self> {
+                let data = call_hyprctl_data_cmd_async($cmd_kind).await;
+                let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
+                Ok(Self(deserialized))
+            }
+        }
 
         impl HyprDataVec<$holding_type> for $name {
             fn to_vec(self) -> Vec<$holding_type> {
@@ -100,6 +169,14 @@ macro_rules! create_data_struct {
         #[doc = $doc]
         #[derive(Debug)]
         pub struct $name(HashMap<$key, $value>);
+
+        implement_iterators!(
+            table,
+            name: $name,
+            iterated_field: 0,
+            key: $key,
+            value: $value,
+        );
 
         #[async_trait]
         impl HyprData for $name {

--- a/src/data/macros.rs
+++ b/src/data/macros.rs
@@ -201,22 +201,4 @@ macro_rules! create_data_struct {
             }
         }
     };
-
-    (p $name:ident,$kind:path,$caller:expr,$held:ty,$c:literal) => {
-        #[doc = $c]
-        #[derive(Debug)]
-        pub struct $name($held);
-
-        #[async_trait]
-        impl HyprData for $name {
-            fn get() -> HResult<Self> {
-                let data = call_hyprctl_data_cmd($kind);
-                Ok(Self($caller(data)?))
-            }
-            async fn get_async() -> HResult<Self> {
-                let data = call_hyprctl_data_cmd_async($kind).await;
-                Ok(Self($caller(data)?))
-            }
-        }
-    };
 }

--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -310,12 +310,13 @@ pub struct LayerDisplay {
     pub levels: HashMap<String, Vec<LayerClient>>,
 }
 
-impl LayerDisplay {
-    /// Returns an iterator over the levels map
-    pub fn iter(&self) -> impl Iterator<Item = (&String, &Vec<LayerClient>)> {
-        self.levels.iter()
-    }
-}
+implement_iterators!(
+    table,
+    name: LayerDisplay,
+    iterated_field: levels,
+    key: String,
+    value: Vec<LayerClient>,
+);
 
 create_data_struct!(
     table,

--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -131,16 +131,16 @@ pub struct Monitor {
 #[async_trait]
 impl HyprDataActive for Monitor {
     fn get_active() -> crate::Result<Self> {
-        let mut all = Monitors::get()?;
-        if let Some(it) = all.find(|item| item.focused) {
+        let all = Monitors::get()?;
+        if let Some(it) = all.into_iter().find(|item| item.focused) {
             Ok(it)
         } else {
             panic!("No active monitor?")
         }
     }
     async fn get_active_async() -> crate::Result<Self> {
-        let mut all = Monitors::get_async().await?;
-        if let Some(it) = all.find(|item| item.focused) {
+        let all = Monitors::get_async().await?;
+        if let Some(it) = all.into_iter().find(|item| item.focused) {
             Ok(it)
         } else {
             panic!("No active monitor?")

--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -315,11 +315,12 @@ impl LayerDisplay {
 }
 
 create_data_struct!(
-    sing Layers,
-    DataCommands::Layers,
-    HashMap<String, LayerDisplay>,
-    "This struct holds a hashmap of all current displays, and their layer surfaces",
-    iter_item = (&String, &LayerDisplay)
+    table,
+    name: Layers,
+    command: DataCommands::Layers,
+    key: String,
+    value: LayerDisplay,
+    doc: "This struct holds a hashmap of all current displays, and their layer surfaces"
 );
 
 /// This struct holds information about a mouse device

--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -149,10 +149,11 @@ impl HyprDataActive for Monitor {
 }
 
 create_data_struct!(
-    vec Monitors,
-    DataCommands::Monitors,
-    Monitor,
-    "This struct holds a vector of monitors"
+    vector,
+    name: Monitors,
+    command: DataCommands::Monitors,
+    holding_type: Monitor,
+    doc: "This struct holds a vector of monitors"
 );
 
 /// This struct holds information for a workspace
@@ -195,10 +196,11 @@ impl HyprDataActive for Workspace {
 }
 
 create_data_struct!(
-    vec Workspaces,
-    DataCommands::Workspaces,
-    Workspace,
-    "This type provides a vector of workspaces"
+    vector,
+    name: Workspaces,
+    command: DataCommands::Workspaces,
+    holding_type: Workspace,
+    doc: "This type provides a vector of workspaces"
 );
 
 /// This struct holds information for a client/window
@@ -277,10 +279,11 @@ impl HyprDataActiveOptional for Client {
 }
 
 create_data_struct!(
-    vec Clients,
-    DataCommands::Clients,
-    Client,
-    "This struct holds a vector of clients"
+    vector,
+    name: Clients,
+    command: DataCommands::Clients,
+    holding_type: Client,
+    doc: "This struct holds a vector of clients"
 );
 
 /// This struct holds information about a layer surface/client
@@ -459,10 +462,11 @@ pub struct Bind {
 }
 
 create_data_struct!(
-    vec Binds,
-    DataCommands::Binds,
-    Bind,
-    "This struct holds a vector of binds"
+    vector,
+    name: Binds,
+    command: DataCommands::Binds,
+    holding_type: Bind,
+    doc: "This struct holds a vector of binds"
 );
 
 /// Animation styles

--- a/src/event_listener/mutable.rs
+++ b/src/event_listener/mutable.rs
@@ -134,7 +134,7 @@ impl EventListener {
                     Err(e) => panic!("Error parsing data whith serde: {e}"),
                 },
                 active_monitor: match Monitors::get() {
-                    Ok(mut monitors) => match monitors.find(|item| item.focused) {
+                    Ok(monitors) => match monitors.into_iter().find(|item| item.focused) {
                         Some(mon) => mon.name,
                         None => panic!("No active monitor?"),
                     },


### PR DESCRIPTION
# Changes

- Added `IntoIterator` implementations (consuming, by reference and by mutable reference);
- Added `iter()` and `iter_mut()` (also `into_keys()` and `into_values()` for HashMap types);
- Added macros `implement_iterator!()`;
- Refactored macros `create_data_struct!()` for greater readability and comprehension.

## Warning

It can break backward compatibility for applications, which uses all `Iterator` functions directly. For example:
```rust
let monitors = Monitors::get()?;
// It won't works.
// let _ = monitors.find(|monitor| monitor.focused);
// But the line below works fine.
let _ = monitors.into_iter().find(|monitor| monitor.focused);
```

Motivation? The type can't be both data struct and `Iterator` at the same time, because it is very strange for me.