### PR TITLE
fix: incorrect ActiveWindowChangedV2 address

### DIFF
--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -866,9 +866,9 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 }
             }
             ParsedEventType::ActiveWindowChangedV2 => {
-                let addr = format_event_addr(&captures["address"]);
+                let addr = &captures["address"];
                 if addr != "," {
-                    events.push(Event::ActiveWindowChangedV2(Some(Address::new(addr))));
+                    events.push(Event::ActiveWindowChangedV2(Some(Address::new(format_event_addr(addr)))));
                 } else {
                     events.push(Event::ActiveWindowChangedV2(None));
                 }


### PR DESCRIPTION
as i understand it, the callback to [add_active_window_change_handler](https://docs.rs/hyprland/latest/hyprland/event_listener/struct.EventListener.html#method.add_active_window_change_handler) receives a `Option<WindowEventData>`. which suggests it should be `None` when no window is active.

after a bunch of debugging, i found [this check](https://github.com/hyprland-community/hyprland-rs/blob/8c9e955fad489aa9d3e49995e89407752c7e39be/src/event_listener/shared.rs#L870), which should be done before formatting the address.