### PR TITLE
don't panic in call_hyprctl_data_cmd_async and call_hyprctl_data_cmd

### DIFF
--- a/src/data/macros.rs
+++ b/src/data/macros.rs
@@ -3,12 +3,12 @@ macro_rules! impl_on {
         #[async_trait]
         impl HyprData for $name {
             fn get() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd(DataCommands::$name);
+                let data = call_hyprctl_data_cmd(DataCommands::$name)?;
                 let deserialized: $name = serde_json::from_str(&data)?;
                 Ok(deserialized)
             }
             async fn get_async() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd_async(DataCommands::$name).await;
+                let data = call_hyprctl_data_cmd_async(DataCommands::$name).await?;
                 let deserialized: $name = serde_json::from_str(&data)?;
                 Ok(deserialized)
             }
@@ -148,12 +148,12 @@ macro_rules! create_data_struct {
         #[async_trait]
         impl HyprData for $name {
             fn get() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd($cmd_kind);
+                let data = call_hyprctl_data_cmd($cmd_kind)?;
                 let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }
             async fn get_async() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd_async($cmd_kind).await;
+                let data = call_hyprctl_data_cmd_async($cmd_kind).await?;
                 let deserialized: Vec<$holding_type> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }
@@ -189,13 +189,13 @@ macro_rules! create_data_struct {
         #[async_trait]
         impl HyprData for $name {
             fn get() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd($cmd_kind);
+                let data = call_hyprctl_data_cmd($cmd_kind)?;
                 let deserialized: HashMap<$key, $value> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }
 
             async fn get_async() -> $crate::Result<Self> {
-                let data = call_hyprctl_data_cmd_async($cmd_kind).await;
+                let data = call_hyprctl_data_cmd_async($cmd_kind).await?;
                 let deserialized: HashMap<$key, $value> = serde_json::from_str(&data)?;
                 Ok(Self(deserialized))
             }


### PR DESCRIPTION
fixes #204.

hyprland-rs sometimes panics when device wakes up from sleep.
the panic is [here](https://github.com/hyprland-community/hyprland-rs/blob/7a60845c9bfaf264e4dd9f5d7977f4a1f15599c8/src/data/regular.rs#L17).

I quickly patched it to use in a tool that i made. And i figured that i might as well make a PR.
let me know if i missed something obviously wrong.

i just made both `call_hyprctl_data_cmd` and `call_hyprctl_data_cmd_async` to return a `crate::Result`. all the places that use these functions are already returning a `crate::Result`.