### PR TITLE
Add repository field

### DIFF
--- a/hyprland-macros/Cargo.toml
+++ b/hyprland-macros/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 readme = "README.md"
 edition = "2021"
 homepage = "https://github.com/hyprland-community/hyprland-rs/tree/master/hyprland-macros"
+repository = "https://github.com/hyprland-community/hyprland-rs"
 
 [package.metadata.nix]
 build = true


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).