### PR TITLE
feat(event listener): add `removeworkspacev2` event

### DIFF
--- a/src/event_listener/async_im.rs
+++ b/src/event_listener/async_im.rs
@@ -32,7 +32,9 @@ impl HasAsyncExecutor for AsyncEventListener {
         match event {
             Event::WorkspaceChanged(id) => arm_async!(id, workspace_changed_events, self),
             Event::WorkspaceAdded(id) => arm_async!(id, workspace_added_events, self),
-            Event::WorkspaceDeleted(id) => arm_async!(id, workspace_destroyed_events, self),
+            Event::WorkspaceDeleted(data) => {
+                arm_async!(data, workspace_destroyed_events, self)
+            }
             Event::WorkspaceMoved(evend) => arm_async!(evend, workspace_moved_events, self),
             Event::WorkspaceRename(even) => arm_async!(even, workspace_rename_events, self),
             Event::ActiveMonitorChanged(evend) => {

--- a/src/event_listener/immutable.rs
+++ b/src/event_listener/immutable.rs
@@ -31,7 +31,7 @@ impl HasExecutor for EventListener {
         match event {
             WorkspaceChanged(id) => arm!(id, workspace_changed_events, self),
             WorkspaceAdded(id) => arm!(id, workspace_added_events, self),
-            WorkspaceDeleted(id) => arm!(id, workspace_destroyed_events, self),
+            WorkspaceDeleted(data) => arm!(data, workspace_destroyed_events, self),
             WorkspaceMoved(evend) => arm!(evend, workspace_moved_events, self),
             WorkspaceRename(even) => arm!(even, workspace_rename_events, self),
             ActiveMonitorChanged(evend) => arm!(evend, active_monitor_changed_events, self),

--- a/src/event_listener/mod.rs
+++ b/src/event_listener/mod.rs
@@ -14,7 +14,7 @@ pub use crate::event_listener::async_im::AsyncEventListener;
 
 add_listener!(workspace_change d, WorkspaceType, "on workspace change", "changed workspace to" => id);
 add_listener!(workspace_added, WorkspaceType, "a workspace is created", "workspace was added" => id);
-add_listener!(workspace_destroy ed, WorkspaceType, "a workspace is destroyed", "workspace was destroyed" => id);
+add_listener!(workspace_destroy ed, WorkspaceDestroyedEventData, "a workspace is destroyed", "a workspace was destroyed" => data);
 add_listener!(workspace_moved, MonitorEventData, "a workspace is moved", "workspace was moved" => id);
 add_listener!(workspace_rename, WorkspaceRenameEventData, "a workspace is renamed", "workspace was renamed" => id);
 add_listener!(active_monitor_change d, MonitorEventData, "the active monitor is changed", "Active monitor changed to" => data);

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -330,7 +330,7 @@ fn init_socket_path(socket_type: SocketType) -> crate::Result<PathBuf> {
             hypr_err!("Corrupted Hyprland socket variable: Invalid unicode!")
         }
     };
-    
+
     let mut p: PathBuf;
     fn var_path(instance: String) -> Option<PathBuf> {
         if let Ok(runtime_path) = var("XDG_RUNTIME_DIR") {
@@ -364,7 +364,7 @@ fn init_socket_path(socket_type: SocketType) -> crate::Result<PathBuf> {
     } else {
         hypr_err!("No xdg runtime path found!")
     }
-    
+
     p.push(socket_type.socket_name());
     Ok(p)
 }


### PR DESCRIPTION
Adds a new `add_workspace_destroyed_v2_handler` method to listen to the v2 destroy event. This allows for tracking removal using workspace IDs instead of just their names.

In its current state this isn't perfect but I'm running up against some potential limits of the macros. 

The main issue here is inconsistency with method names:

- The v1 method is `workspace_destroy` while the new one is `workspace_destroyed`
- Elsewhere, where two versions exist, the v1 copy uses the v1 suffix explicitly. Here it's omitted, and only v2 objects are suffixed.

Thought I'd check in before making any decisions on these myself. Let me know what you think the best course of action is here?