### PR TITLE
Fix TabletBelongsTo deserialization

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -365,6 +365,7 @@ pub enum TabletType {
 
 /// A enum to match what the tablet belongs to
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(untagged)]
 pub enum TabletBelongsTo {
     /// The belongsTo data if the tablet is of type TabletPad
     TabletPad {


### PR DESCRIPTION
Fixes #253 

In the output of `hyprctl -j devices`, `.tablets[].belongsTo` is an object, which we try to deserialize into the `TabletBelongsTo` enum. However, this JSON object is just a "flat" object, containing the fields of one of the enum variants, without a tag specifying which variant it is. So we must use `#[serde(untagged)]` to correctly deserialize it

---

edit: technically there *is* a tag: the `type` field in the parent object:

```
{
    "address": "0x627fa3b386f0",
    "type": "tabletPad",                     <--
    "belongsTo": {
      "address": "0x0",
      "name": ""
    }
  },
```

Lmk if this solution is acceptable or if should instead take that `type` field into account (practically I don't think there's a difference)
