### PR TITLE
Make `EventStream` `Send`

### DIFF
--- a/src/event_listener/stream.rs
+++ b/src/event_listener/stream.rs
@@ -28,7 +28,7 @@ use futures_lite::{Stream, StreamExt};
 /// ```
 #[must_use = "streams nothing unless polled"]
 pub struct EventStream {
-    stream: Pin<Box<dyn Stream<Item = crate::Result<Event>>>>,
+    stream: Pin<Box<dyn Stream<Item = crate::Result<Event>> + Send>>,
 }
 impl EventStream {
     /// Creates a new [EventListener]


### PR DESCRIPTION
As discussed in #284, add `+ Send` in the trait object owned by `EventStream` in order to allow its use when spawning new async tasks.