### PR TITLE
Fix some examples failing compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hyprland"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "ahash",
  "async-net",
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "hyprland-macros"
-version = "0.4.0-beta.1"
+version = "0.4.0-beta.2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/examples/bind.rs
+++ b/examples/bind.rs
@@ -11,8 +11,8 @@ use hyprland::keyword::Keyword;
 fn main() -> hyprland::Result<()> {
     Keyword::set("submap", "example")?;
     hyprland::bind!(SUPER, Key, "I" => ToggleFloating, None)?;   
-    hyprland::bind!(l | CTRL ALT, Key, "Delete" => Exec, "sudo reboot"); // Reboot including from lock screen
-    hyprland::bind!(e | SUPER, Key, "C" => KillActiveWindow); // Kill all your windows  
+    hyprland::bind!(l | CTRL ALT, Key, "Delete" => Exec, "sudo reboot")?; // Reboot including from lock screen
+    hyprland::bind!(e | SUPER, Key, "C" => KillActiveWindow)?; // Kill all your windows  
     Keyword::set("submap", "reset")?;
 
     dispatch!(Custom, "submap", "example")?;

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -8,12 +8,12 @@ fn main() -> hyprland::Result<()> {
     // Create a event listener
     let mut event_listener = EventListener::new();
 
-    event_listener.add_active_window_change_handler(|data| println!("{data:#?}"));
-    event_listener.add_fullscreen_state_change_handler(
+    event_listener.add_active_window_changed_handler(|data| println!("{data:#?}"));
+    event_listener.add_fullscreen_state_changed_handler(
         |fstate| println!("Window {} fullscreen", if fstate { "is" } else { "is not" })
     );
-    event_listener.add_active_monitor_change_handler(|state| println!("Monitor state: {state:#?}"));    
-    event_listener.add_workspace_change_handler(|id| println!("workspace changed to {id:?}"));
+    event_listener.add_active_monitor_changed_handler(|state| println!("Monitor state: {state:#?}"));    
+    event_listener.add_workspace_changed_handler(|id| println!("workspace changed to {id:?}"));
 
     // and execute the function
     // here we are using the blocking variant

--- a/examples/events_async.rs
+++ b/examples/events_async.rs
@@ -10,20 +10,20 @@ async fn main() -> hyprland::Result<()> {
     // Create a event listener
     let mut event_listener = AsyncEventListener::new();
 
-    event_listener.add_active_window_change_handler(async_closure! {
+    event_listener.add_active_window_changed_handler(async_closure! {
         |data| println!("{data:#?}")
     });
 
-    event_listener.add_fullscreen_state_change_handler(async_closure! {
+    event_listener.add_fullscreen_state_changed_handler(async_closure! {
         |fstate| println!("Window {} fullscreen", if fstate { "is" } else { "is not" })
     });
 
-    event_listener.add_active_monitor_change_handler(async_closure! {
+    event_listener.add_active_monitor_changed_handler(async_closure! {
         |state| println!("Monitor state: {state:#?}")
     });
 
     // add event, yes functions and closures both work!
-    event_listener.add_workspace_change_handler(async_closure! {
+    event_listener.add_workspace_changed_handler(async_closure! {
         |id| println!("workspace changed to {id:?}")
     });
 

--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -72,7 +72,7 @@ pub(crate) trait HasExecutor {
     }
 }
 
-pub(crate) fn event_primer_noexec<'a>(
+pub(crate) fn event_primer_noexec(
     event: Event,
     abuf: &mut Vec<ActiveWindowState>,
 ) -> crate::Result<Vec<Event>> {
@@ -688,7 +688,7 @@ fn new_event_parser(
             if let Some(event) = EVENTS.get(name) {
                 Either::Left((
                     event.1,
-                    x.splitn(event.0 as usize, ",")
+                    x.splitn(event.0, ",")
                         .map(|y| y.to_string())
                         .collect(),
                 ))
@@ -879,7 +879,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
                 toggled: get![ref args;0] == "1",
                 window_addresses: get![ref args;1]
                     .split(",")
-                    .map(|x| Address::new(x))
+                    .map(Address::new)
                     .collect(),
             })),
             ParsedEventType::MoveIntoGroup => {


### PR DESCRIPTION
* Fix `hyprland::bind!()` warnings in `examples/bind.rs` because the `Result` was not being checked
* Fix typo in some generated methods (`change` => `changed`), I assume the macro changed at some point?
* I also took care of some clippy warnings (2nd commit)

I noticed the bind test still fails though: 
```
---- config::test_binds stdout ----
thread 'config::test_binds' panicked at src/config.rs:269:5:
assertion `left == right` failed
  left: "SUPER,v,togglefloating"
 right: "SUPER,v,/togglefloating"
```
I'm not sure what the fix would be here? Does `Binder::gen_str` need to be updated to include the `/`, or should the expected value (right) be without the `/`?