### PR TITLE
add "class:" prefix to class regex window identifier

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -25,7 +25,7 @@ pub enum WindowIdentifier<'a> {
     #[display("address:{_0}")]
     Address(Address),
     /// A Regular Expression to match the window class (handled by Hyprland)
-    #[display("{_0}")]
+    #[display("class:{_0}")]
     ClassRegularExpression(&'a str),
     /// The window title
     #[display("title:{_0}")]


### PR DESCRIPTION
In hyprland 0.46.0, usage of std::regex was replaced with re2, and as an (unintended?) side effect, the "class:" prefix has become mandatory when matching windows by class name regex

https://github.com/hyprwm/Hyprland/pull/8736

https://github.com/hyprwm/Hyprland/pull/8736/files#diff-3c089c6c6b23a85ab5b4cffb002e8880ad069c8a8b3462f7aafa9e5345c0333dL2395-R2397