### PR TITLE
fix: unbreak examples events & events_async

### DIFF
--- a/examples/events.rs
+++ b/examples/events.rs
@@ -8,12 +8,12 @@ fn main() -> hyprland::Result<()> {
     // Create a event listener
     let mut event_listener = EventListener::new();
 
-    event_listener.add_active_window_change_handler(|data| println!("{data:#?}"));
-    event_listener.add_fullscreen_state_change_handler(
+    event_listener.add_active_window_changed_handler(|data| println!("{data:#?}"));
+    event_listener.add_fullscreen_state_changed_handler(
         |fstate| println!("Window {} fullscreen", if fstate { "is" } else { "is not" })
     );
-    event_listener.add_active_monitor_change_handler(|state| println!("Monitor state: {state:#?}"));    
-    event_listener.add_workspace_change_handler(|id| println!("workspace changed to {id:?}"));
+    event_listener.add_active_monitor_changed_handler(|state| println!("Monitor state: {state:#?}"));    
+    event_listener.add_workspace_changed_handler(|id| println!("workspace changed to {id:?}"));
 
     // and execute the function
     // here we are using the blocking variant

--- a/examples/events_async.rs
+++ b/examples/events_async.rs
@@ -1,6 +1,6 @@
 /// Demostrats using hyprland-rs to asynchronously listen for events
 /// 
-/// Usage: cargo run --example events
+/// Usage: cargo run --example events_async
 
 use hyprland::async_closure;
 use hyprland::event_listener::AsyncEventListener;
@@ -10,20 +10,20 @@ async fn main() -> hyprland::Result<()> {
     // Create a event listener
     let mut event_listener = AsyncEventListener::new();
 
-    event_listener.add_active_window_change_handler(async_closure! {
+    event_listener.add_active_window_changed_handler(async_closure! {
         |data| println!("{data:#?}")
     });
 
-    event_listener.add_fullscreen_state_change_handler(async_closure! {
+    event_listener.add_fullscreen_state_changed_handler(async_closure! {
         |fstate| println!("Window {} fullscreen", if fstate { "is" } else { "is not" })
     });
 
-    event_listener.add_active_monitor_change_handler(async_closure! {
+    event_listener.add_active_monitor_changed_handler(async_closure! {
         |state| println!("Monitor state: {state:#?}")
     });
 
     // add event, yes functions and closures both work!
-    event_listener.add_workspace_change_handler(async_closure! {
+    event_listener.add_workspace_changed_handler(async_closure! {
         |id| println!("workspace changed to {id:?}")
     });
 


### PR DESCRIPTION
the names for the change_handler functions were probably renamed to changed_handler and the events & events_async examples no longer work. this just changes them.