### PR TITLE
Fix active window ready state

### DIFF
--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -793,7 +793,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
             }
             ParsedEventType::ActiveWindowChangedV2 => {
                 let addr = get![ref args;0];
-                let event = if addr != "," {
+                let event = if addr != "," && !addr.is_empty() {
                     Event::ActiveWindowChangedV2(Some(Address::new(addr)))
                 } else {
                     Event::ActiveWindowChangedV2(None)

--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -793,7 +793,7 @@ pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
             }
             ParsedEventType::ActiveWindowChangedV2 => {
                 let addr = get![ref args;0];
-                let event = if addr != "," && !addr.is_empty() {
+                let event = if !addr.is_empty() {
                     Event::ActiveWindowChangedV2(Some(Address::new(addr)))
                 } else {
                     Event::ActiveWindowChangedV2(None)


### PR DESCRIPTION
## Fix empty address handling in ActiveWindowChangedV2 events

Currently, switching to empty workspaces doesn't trigger `ActiveWindowChangedV2` events because the parser only checks for a comma, but `activewindowv2` events contain a single address field instead of multiple comma separated ones.

### Problem
Switching to an empty while listening on the IPC socket one sees `activewindowv2>>` switching back to a non-empty one, one sees `activewindowv2>>371d2fd0`

### Solution
the current fix checks for `!addr.is_empty()` instead of `addr != ","`