### PR TITLE
fix(RUSTSEC-2024-0436): replace paste with pastey

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "parking_lot",
- "paste",
+ "pastey",
  "phf",
  "serde",
  "serde_json",
@@ -590,10 +590,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "phf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ async-net = { version = "2.0", optional = true }
 async-std = { version = "1.13", optional = true }
 futures-lite = { version = "2.3", default-features = false }
 num-traits = "0.2.19"
-paste = "1.0.14"
+paste = { version = "0.1.1", package = "pastey" }
 derive_more = { version = "1.0.0", features = [
     "display",
     "constructor",


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2024-0436.html

From the pastey README:
"pastey is the fork of paste and is aimed to be a drop-in replacement
with additional features for paste crate"
