### PR TITLE
Fix hyprpaper sync to use Hyprpaper socket

### DIFF
--- a/src/hyprpaper.rs
+++ b/src/hyprpaper.rs
@@ -39,7 +39,7 @@ pub fn hyprpaper(keyword: Keyword) -> crate::Result<Response> {
         data: keyword.to_string(),
     };
 
-    let response = write_to_socket_sync(SocketType::Command, content)?;
+    let response = write_to_socket_sync(SocketType::Hyprpaper, content)?;
 
     expected_response.is_expected(response)
 }


### PR DESCRIPTION
Fixes #329

Updates the sync `hyprpaper` function to use the hyprpaper socket so it no longer returns "unknown request".