### PR TITLE
feat: add ToggleFullscreenState dispatcher

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -427,7 +427,7 @@ pub enum DispatchType<'a> {
     /// This dispatcher toggles the current window fullscreen state
     ToggleFullscreen(FullscreenType),
     /// This dispatcher sets the focused window’s fullscreen mode and the one sent to the client
-    ToggleFullscreenState(FullscreenState, FullscreenType),
+    ToggleFullscreenState(FullscreenState, FullscreenState),
     /// This dispatcher toggles the focused window’s internal
     /// fullscreen state without altering the geometry
     ToggleFakeFullscreen,

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -52,6 +52,23 @@ pub enum FullscreenType {
     NoParam,
 }
 
+/// This enum is the params to [DispatchType::ToggleFullscreenState] dispatcher
+#[allow(missing_docs)]
+#[derive(Debug, Clone, Copy)]
+pub enum FullscreenState {
+    Current = -1,
+    None = 0,
+    Maximize = 1,
+    Fullscreen = 2,
+    MaximizeFullscreen = 3,
+}
+
+impl std::fmt::Display for FullscreenState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", *self as u8)
+    }
+}
+
 /// This enum holds directions, typically used for moving
 #[derive(Debug, Clone, Display)]
 #[allow(missing_docs)]
@@ -409,6 +426,8 @@ pub enum DispatchType<'a> {
     ToggleFloating(Option<WindowIdentifier<'a>>),
     /// This dispatcher toggles the current window fullscreen state
     ToggleFullscreen(FullscreenType),
+    /// This dispatcher sets the focused window’s fullscreen mode and the one sent to the client
+    ToggleFullscreenState(FullscreenState, FullscreenType),
     /// This dispatcher toggles the focused window’s internal
     /// fullscreen state without altering the geometry
     ToggleFakeFullscreen,
@@ -654,6 +673,7 @@ pub(crate) fn gen_dispatch_str(cmd: DispatchType, dispatch: bool) -> crate::Resu
         ToggleFloating(Some(v)) => format!("togglefloating{sep}{v}"),
         ToggleFloating(None) => "togglefloating".to_string(),
         ToggleFullscreen(ftype) => format!("fullscreen{sep}{ftype}"),
+        ToggleFullscreenState(int, cl) => format!("fullscreenstate{sep}{int} {cl}"),
         ToggleFakeFullscreen => "fakefullscreen".to_string(),
         ToggleDPMS(stat, mon) => {
             format!(


### PR DESCRIPTION
Add the replacement to the `fakefullscreen`, which has been removed from Hyprland in version `v0.42.0`. You may want to remove the `ToggleFakeFullscreen` dispatcher unless you want to support older versions of Hyprland.