### PR TITLE
Add bind description field

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -493,6 +493,8 @@ pub struct Bind {
     pub dispatcher: String,
     /// The dispatcher arg
     pub arg: String,
+    /// description from bind[d]
+    pub description: String,
 }
 
 create_data_struct!(


### PR DESCRIPTION
Wanted bind description field in a toy project but it is currently missing from `Bind`.