### PR TITLE
Added a blacklist to ignore outdated event's 

### DIFF
--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -72,6 +72,19 @@ pub(crate) trait HasExecutor {
     }
 }
 
+const BLACKLISTED_UNKNOWN_EVENTS: &[&str; 10] = &[
+    "workspace",
+    "focusedmon",
+    "monitorremoved",
+    "monitoradded",
+    "createworkspace",
+    "destroyworkspace",
+    "moveworkspace",
+    "activespecial",
+    "movewindow",
+    "windowtitle",
+];
+
 #[cfg(any(feature = "async-lite", feature = "tokio"))]
 pub(crate) fn event_primer_noexec(
     event: Event,
@@ -115,6 +128,10 @@ pub(crate) fn event_primer_noexec(
         }
         for index in to_remove.into_iter().rev() {
             abuf.swap_remove(index);
+        }
+    } else if let Event::Unknown(ref data) = event {
+        if !BLACKLISTED_UNKNOWN_EVENTS.contains(&&*data.name) {
+            events.push(event);
         }
     } else {
         events.push(event);


### PR DESCRIPTION
Before this change every "outdated" event would show up in the EventStream as a unknown Event. I'm not sure if that's intentional but it seems rather weird. If it's indeed intentional feel free to close this PR.