### PR TITLE
Replace `String::from_utf8` with `String::from_utf8_lossy` to handle non-UTF-8 window titles (e.g., FarCry®6)

### DIFF
--- a/src/event_listener/async_im.rs
+++ b/src/event_listener/async_im.rs
@@ -90,7 +90,7 @@ impl AsyncEventListener {
                 break;
             }
             let buf = &buffer[..bytes_read];
-            let string = String::from_utf8(buf.to_vec())?;
+            let string = String::from_utf8_lossy(buf).to_string();
             let parsed: Vec<Event> = event_parser(string)?;
             for event in parsed {
                 self.event_primer_exec_async(event, &mut active_windows)

--- a/src/event_listener/async_im.rs
+++ b/src/event_listener/async_im.rs
@@ -90,8 +90,8 @@ impl AsyncEventListener {
                 break;
             }
             let buf = &buffer[..bytes_read];
-            let string = String::from_utf8_lossy(buf).to_string();
-            let parsed: Vec<Event> = event_parser(string)?;
+            let string = String::from_utf8_lossy(buf);
+            let parsed: Vec<Event> = event_parser(&string)?;
             for event in parsed {
                 self.event_primer_exec_async(event, &mut active_windows)
                     .await?;

--- a/src/event_listener/immutable.rs
+++ b/src/event_listener/immutable.rs
@@ -92,7 +92,7 @@ impl EventListener {
                 break;
             }
             let buf = &buffer[..bytes_read];
-            let string = String::from_utf8(buf.to_vec())?;
+            let string = String::from_utf8_lossy(buf).to_string();
             let parsed: Vec<Event> = event_parser(string)?;
             for event in parsed {
                 self.event_primer(event, &mut active_windows)?;
@@ -146,7 +146,7 @@ impl EventListener {
                 break;
             }
             let buf = &buffer[..bytes_read];
-            let string = String::from_utf8(buf.to_vec())?;
+            let string = String::from_utf8_lossy(buf).to_string();
             let parsed: Vec<Event> = event_parser(string)?;
             for event in parsed {
                 self.event_primer(event, &mut active_windows)?;

--- a/src/event_listener/immutable.rs
+++ b/src/event_listener/immutable.rs
@@ -92,8 +92,8 @@ impl EventListener {
                 break;
             }
             let buf = &buffer[..bytes_read];
-            let string = String::from_utf8_lossy(buf).to_string();
-            let parsed: Vec<Event> = event_parser(string)?;
+            let string = String::from_utf8_lossy(buf);
+            let parsed: Vec<Event> = event_parser(&string)?;
             for event in parsed {
                 self.event_primer(event, &mut active_windows)?;
             }
@@ -146,8 +146,8 @@ impl EventListener {
                 break;
             }
             let buf = &buffer[..bytes_read];
-            let string = String::from_utf8_lossy(buf).to_string();
-            let parsed: Vec<Event> = event_parser(string)?;
+            let string = String::from_utf8_lossy(buf);
+            let parsed: Vec<Event> = event_parser(&string)?;
             for event in parsed {
                 self.event_primer(event, &mut active_windows)?;
             }

--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -782,7 +782,7 @@ macro_rules! get {
 }
 
 /// This internal function parses event strings
-pub(crate) fn event_parser(event: String) -> crate::Result<Vec<Event>> {
+pub(crate) fn event_parser(event: &str) -> crate::Result<Vec<Event>> {
     // TODO: Optimize nested looped regex capturing. Maybe pull in rayon if possible.
     let event_iter = event.trim().lines().filter_map(|event_line| {
         if event_line.is_empty() {

--- a/src/event_listener/stream.rs
+++ b/src/event_listener/stream.rs
@@ -53,8 +53,8 @@ impl EventStream {
                     break;
                 }
                 let buf = &buffer[..bytes_read];
-                let string = String::from_utf8_lossy(buf).to_string();
-                let parsed: Vec<Event> = event_parser(string)?;
+                let string = String::from_utf8_lossy(buf);
+                let parsed: Vec<Event> = event_parser(&string)?;
                 for event in parsed {
                     for primed_event in event_primer_noexec(event, &mut active_windows)? {
                         yield primed_event;
@@ -81,8 +81,8 @@ impl EventStream {
                     break;
                 }
                 let buf = &buffer[..bytes_read];
-                let string = String::from_utf8_lossy(buf).to_string();
-                let parsed: Vec<Event> = event_parser(string)?;
+                let string = String::from_utf8_lossy(buf);
+                let parsed: Vec<Event> = event_parser(&string)?;
                 for event in parsed {
                     for primed_event in event_primer_noexec(event, &mut active_windows)? {
                         yield primed_event;

--- a/src/event_listener/stream.rs
+++ b/src/event_listener/stream.rs
@@ -53,7 +53,7 @@ impl EventStream {
                     break;
                 }
                 let buf = &buffer[..bytes_read];
-                let string = String::from_utf8(buf.to_vec())?;
+                let string = String::from_utf8_lossy(buf).to_string();
                 let parsed: Vec<Event> = event_parser(string)?;
                 for event in parsed {
                     for primed_event in event_primer_noexec(event, &mut active_windows)? {
@@ -81,7 +81,7 @@ impl EventStream {
                     break;
                 }
                 let buf = &buffer[..bytes_read];
-                let string = String::from_utf8(buf.to_vec())?;
+                let string = String::from_utf8_lossy(buf).to_string();
                 let parsed: Vec<Event> = event_parser(string)?;
                 for event in parsed {
                     for primed_event in event_primer_noexec(event, &mut active_windows)? {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -69,7 +69,7 @@ impl Instance {
         stream.write_all(&content.as_bytes())?;
         let mut response = Vec::new();
         stream.read_to_end(&mut response)?;
-        Ok(String::from_utf8(response)?)
+        Ok(String::from_utf8_lossy(&response).to_string())
     }
 
     #[cfg(any(feature = "async-lite", feature = "tokio"))]
@@ -82,7 +82,7 @@ impl Instance {
         stream.write_all(&content.as_bytes()).await?;
         let mut response = Vec::new();
         stream.read_to_end(&mut response).await?;
-        Ok(String::from_utf8(response)?)
+        Ok(String::from_utf8_lossy(&response).to_string())
     }
 
     #[cfg(feature = "hyprpaper")]
@@ -104,7 +104,7 @@ impl Instance {
                 break;
             }
         }
-        Ok(String::from_utf8(response)?)
+        Ok(String::from_utf8_lossy(&response).to_string())
     }
 
     #[cfg(all(feature = "hyprpaper", any(feature = "async-lite", feature = "tokio")))]
@@ -126,7 +126,7 @@ impl Instance {
                 break;
             }
         }
-        Ok(String::from_utf8(response)?)
+        Ok(String::from_utf8_lossy(&response).to_string())
     }
 
     #[cfg(feature = "listener")]


### PR DESCRIPTION
## Problem
Some games, like FarCry 6, use Windows-1252 encoding instead of UTF-8 in their titles. While normal ASCII characters are fine, non-UTF-8 characters such as `®` cause `HyprError::FromUtf8Error` for example, when calling `EventListener::instance_start_listener`.

Example output from `hyprctl`:
```
Window 55717aa88dd0 -> FarCry®6:
	mapped: 1
	hidden: 1
	at: 0,0
	size: 3360,1440
	workspace: 4 (4)
	floating: 1
	monitor: 0
	class: steam_app_2369390
	title: FarCry®6
	initialClass: steam_app_2369390
	initialTitle: Dunia
	pid: 139761
	xwayland: 1
	pinned: 0
	fullscreen: 2
	fullscreenClient: 2
	overFullscreen: 1
	grouped: 0
	tags:
	swallowing: 0
	focusHistoryID: 0
	inhibitingIdle: 0
	xdgTag:
	xdgDescription:
	contentType: none
	stableID: 180004cf
```
Example Error:
```
FromUtf8Error(FromUtf8Error { bytes: [119, 105, 110, 100, 111, 119, 116, 105, 116, 108, 101, 62, 62, 53, 53, 54, 50, 52, 48, 99, 54, 54, 100, 99, 48, 10, 119, 105, 110, 100, 111, 119, 116, 105, 116, 108, 101, 118, 50, 62, 62, 53, 53, 54, 50, 52, 48, 99, 54, 54, 100, 99, 48, 44, 70, 97, 114, 67, 114, 121, 174, 54, 10], error: Utf8Error { valid_up_to: 60, error_len: Some(1) } })
```
## Proposed Solution
Replace all calls to `String::from_utf8` with `String::from_utf8_lossy`. This ensures invalid UTF-8 sequences are replaced with `�` rather than causing an error. For example, `FarCry®6` would appear as `FarCry�6`.
Optionally, `HyprError::FromUtf8Error` could be removed, since invalid UTF-8 should no longer propagate as an error.

### Alternative Approach
Attempt UTF-8 decoding first, and then if that returns an error, fall back to Windows-1252.
However, this poses the question of how many and which fallback encodings to consider.