### PR TITLE
feat(dispatch): add `sendshortcut` dispatcher

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,21 +41,7 @@ pub mod binds {
         }
     }
 
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
-    #[allow(missing_docs)]
-    /// Enum for mod keys used in bind combinations
-    pub enum Mod {
-        #[display("SUPER")]
-        SUPER,
-        #[display("SHIFT")]
-        SHIFT,
-        #[display("ALT")]
-        ALT,
-        #[display("CTRL")]
-        CTRL,
-        #[display("")]
-        NONE,
-    }
+    pub use crate::shared::Mod;
 
     impl Join for Vec<Mod> {
         fn join(&self) -> String {

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -495,8 +495,8 @@ pub enum DispatchType<'a> {
     TogglePinWindow(WindowIdentifier<'a>),
     /// This dispatcher sends a shortcut to the specified window
     SendShortcut(
-        /// The modifiers, e.g., "SUPER" or "SUPER_SHIFT" (see Hyprland docs)
-        &'a str,
+        /// The modifiers
+        &'a [crate::shared::Mod],
         /// The key, e.g., "A"
         &'a str,
         /// The window identifier
@@ -788,8 +788,13 @@ pub(crate) fn gen_dispatch_str(cmd: DispatchType, dispatch: bool) -> crate::Resu
         TogglePseudo => "pseudo".to_string(),
         TogglePin => "pin".to_string(),
         TogglePinWindow(win) => format!("pin{sep}{win}"),
-        SendShortcut(mods, key, Some(win)) => format!("sendshortcut{sep}{mods},{key},{win}"),
-        SendShortcut(mods, key, None) => format!("sendshortcut{sep}{mods},{key},"),
+        SendShortcut(mods, key, win_opt) => {
+            let mods_str: String = mods.iter().map(|m| m.to_string()).collect();
+            match win_opt {
+                Some(win) => format!("sendshortcut{sep}{mods_str},{key},{win}"),
+                None => format!("sendshortcut{sep}{mods_str},{key},"),
+            }
+        }
         MoveFocus(dir) => format!("movefocus{sep}{dir}",),
         MoveWindow(ident) => format!(
             "movewindow{sep}{}",

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -493,6 +493,15 @@ pub enum DispatchType<'a> {
     TogglePin,
     /// This dispatcher pins the specified window to all workspaces
     TogglePinWindow(WindowIdentifier<'a>),
+    /// This dispatcher sends a shortcut to the specified window
+    SendShortcut(
+        /// The modifiers, e.g., "SUPER" or "SUPER_SHIFT" (see Hyprland docs)
+        &'a str,
+        /// The key, e.g., "A"
+        &'a str,
+        /// The window identifier
+        Option<WindowIdentifier<'a>>,
+    ),
     /// This dispatcher sends a signal to the active window
     Signal(SignalType),
     /// This dispatcher sends a signal to the specified window
@@ -779,6 +788,8 @@ pub(crate) fn gen_dispatch_str(cmd: DispatchType, dispatch: bool) -> crate::Resu
         TogglePseudo => "pseudo".to_string(),
         TogglePin => "pin".to_string(),
         TogglePinWindow(win) => format!("pin{sep}{win}"),
+        SendShortcut(mods, key, Some(win)) => format!("sendshortcut{sep}{mods},{key},{win}"),
+        SendShortcut(mods, key, None) => format!("sendshortcut{sep}{mods},{key},"),
         MoveFocus(dir) => format!("movefocus{sep}{dir}",),
         MoveWindow(ident) => format!(
             "movewindow{sep}{}",

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -255,3 +255,19 @@ macro_rules! command {
 use crate::error::hypr_err;
 use crate::instance::Instance;
 pub use command;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
+#[allow(missing_docs)]
+/// Enum for mod keys used in bind combinations
+pub enum Mod {
+    #[display("SUPER")]
+    SUPER,
+    #[display("SHIFT")]
+    SHIFT,
+    #[display("ALT")]
+    ALT,
+    #[display("CTRL")]
+    CTRL,
+    #[display("")]
+    NONE,
+}


### PR DESCRIPTION
This PR adds the missing `sendshortcut` dispatcher to the `DispatchType` enum, as requested in #368.

I implemented it to accept an optional `WindowIdentifier` so it matches Hyprland's behavior (falling back to the active window if no specific window is passed).

Resolves #368.