### PR TITLE
fix: doc tests and clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! # Hyprland Configuration in Rust
 //!
 
-use crate::dispatch::{gen_dispatch_str, DispatchType};
+use crate::dispatch::{DispatchType, gen_dispatch_str};
 use crate::keyword::Keyword;
 
 /// Module providing stuff for adding an removing keybinds
@@ -53,7 +53,7 @@ pub mod binds {
         }
     }
 
-    impl<'a> Join for &'a [Mod] {
+    impl Join for &[Mod] {
         fn join(&self) -> String {
             let mut buf = String::new();
             for i in *self {
@@ -109,7 +109,7 @@ pub mod binds {
         }
     }
 
-    impl<'a> Join for &'a [Flag] {
+    impl Join for &[Flag] {
         fn join(&self) -> String {
             let mut buf = String::new();
             for f in *self {
@@ -227,13 +227,15 @@ pub mod binds {
     /// Very macro basic abstraction over [Binder] for internal use, **Dont use this instead use [crate::bind]**
     ///
     /// ```rust
-    /// # use hyprland::{bind_raw, default_instance, default_instance_panic, dispatch::DispatchType};
-    /// # async fn test() {
+    /// # use hyprland::{bind_raw, default_instance, default_instance_panic, dispatch::DispatchType, Result};
+    /// #[tokio::main(flavor = "current_thread")]
+    /// # async fn test() -> Result<()> {
     ///   let instance = default_instance()?;
-    ///   bind_raw!(instance , vec! [ Mod :: SHIFT ] , Key :: Key ( "m"  ) ,  vec ! [ Flag :: l , Flag :: r , Flag :: m ] ,  DispatchType :: Exit )?;
-    ///   bind_raw!(vec! [ Mod :: SHIFT ] , Key :: Key ( "m"  ) ,  vec ! [ Flag :: l , Flag :: r , Flag :: m ] ,  DispatchType :: Exit )?;
-    ///   bind_raw!(async, instance, vec ! [ Mod :: SHIFT ] , Key :: Key ( "m"  ) ,  vec ! [ Flag :: l , Flag :: r , Flag :: m ] ,  DispatchType :: Exit ).await?;
-    ///   bind_raw!(async, vec ! [ Mod :: SHIFT ] , Key :: Key ( "m"  ) ,  vec ! [ Flag :: l , Flag :: r , Flag :: m ] ,  DispatchType :: Exit ).await?;
+    ///   bind_raw!(instance , &[Mod::SHIFT] , Key::Key("m")  ,  &[Flag::l, Flag::r, Flag::m] ,  DispatchType::Exit )?;
+    ///   bind_raw!(&[Mod::SHIFT] , Key::Key("m")  ,  &[Flag::l, Flag::r, Flag::m] ,  DispatchType::Exit )?;
+    ///   bind_raw!(async, instance, &[Mod::SHIFT] , Key::Key("m")  ,  &[Flag::l, Flag::r, Flag::m] ,  DispatchType::Exit).await?;
+    ///   bind_raw!(async, &[Mod::SHIFT] , Key::Key("m")  ,  &[Flag::l, Flag::r, Flag::m] ,  DispatchType::Exit).await?;
+    ///   Ok(())
     /// # }
     /// ```
     #[macro_export]
@@ -283,16 +285,18 @@ pub mod binds {
     /// Macro abstraction over [Binder]
     ///
     /// ```rust
-    /// # use hyprland::{bind, default_instance_panic};
+    /// # use hyprland::{bind, default_instance, dispatch::DispatchType, Result};
     /// # use hyprland::instance::Instance;
     ///
-    /// # async fn test() {
+    /// #[tokio::main(flavor = "current_thread")]
+    /// # async fn test() -> Result<()> {
     ///     let instance = default_instance()?;
     ///     bind!(instance, l r m | SHIFT, Key, "m" => Exit);
     ///     bind!(SHIFT ALT, Key, "b" => CenterWindow);
     ///     bind!(async ; l r m | SHIFT, Key, "m" => Exit);
-    ///     bind!(async ; instance,  SUPER, Mod, vec![Mod::SUPER], "l" => CenterWindow);
+    ///     bind!(async ; instance, SUPER, Key, "l" => CenterWindow);
     ///     bind!(async ; SHIFT ALT, Key, "b" => CenterWindow);
+    ///     Ok(())
     /// # }
     /// ```
     #[macro_export]

--- a/src/ctl.rs
+++ b/src/ctl.rs
@@ -430,11 +430,7 @@ pub mod set_prop {
     use super::*;
 
     fn l(b: bool) -> &'static str {
-        if b {
-            "lock"
-        } else {
-            ""
-        }
+        if b { "lock" } else { "" }
     }
 
     /// Type that represents a prop

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -13,28 +13,28 @@
 //! fn main() -> Result<()> {
 //!     let instance = &hyprland::instance::Instance::from_current_env()?;
 //!
-//!     let monitors = Monitors::get(instance)?.to_vec();
+//!     let monitors = Monitors::instance_get(instance)?.to_vec();
 //!     println!("{monitors:#?}");
 //!
-//!     let workspaces = Workspaces::get(instance)?.to_vec();
+//!     let workspaces = Workspaces::instance_get(instance)?.to_vec();
 //!     println!("{workspaces:#?}");
 //!
-//!     let clients = Clients::get(instance)?.to_vec();
+//!     let clients = Clients::instance_get(instance)?.to_vec();
 //!     println!("{clients:#?}");
 //!
-//!     let active_window = Client::get_active(instance)?;
+//!     let active_window = Client::instance_get_active(instance)?;
 //!     println!("{active_window:#?}");
 //!
-//!     let layers = Layers::get(instance)?;
+//!     let layers = Layers::instance_get(instance)?;
 //!     println!("{layers:#?}");
 //!
-//!     let devices = Devices::get(instance)?;
+//!     let devices = Devices::instance_get(instance)?;
 //!     println!("{devices:#?}");
 //!
-//!     let version = Version::get(instance)?;
+//!     let version = Version::instance_get(instance)?;
 //!     println!("{version:#?}");
 //!
-//!     let cursor_pos = CursorPosition::get(instance)?;
+//!     let cursor_pos = CursorPosition::instance_get(instance)?;
 //!     println!("{cursor_pos:#?}");
 //!     Ok(())
 //! }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -935,8 +935,10 @@ impl Dispatch {
     ///
     /// ```rust
     /// # use hyprland::Result;
+    /// #[tokio::main(flavor = "current_thread")]
     /// # async fn main() -> Result<()> {
     /// use hyprland::dispatch::{Dispatch,DispatchType};
+    /// let instance = hyprland::instance::Instance::from_current_env()?;
     /// // This is an example of just one dispatcher, there are many more!
     /// Dispatch::call_async(DispatchType::Exec("kitty")).await
     /// # }
@@ -950,11 +952,12 @@ impl Dispatch {
     ///
     /// ```rust
     /// # use hyprland::Result;
+    /// #[tokio::main(flavor = "current_thread")]
     /// # async fn main() -> Result<()> {
     /// use hyprland::dispatch::{Dispatch,DispatchType};
     /// let instance = hyprland::instance::Instance::from_current_env()?;
     /// // This is an example of just one dispatcher, there are many more!
-    /// Dispatch::instance_call_async(&instance, DispatchType::Exec("kitty")).await
+    /// Dispatch::call_async(DispatchType::Exec("kitty")).await
     /// # }
     /// ```
     #[cfg(any(feature = "async-lite", feature = "tokio"))]

--- a/src/event_listener/async_im.rs
+++ b/src/event_listener/async_im.rs
@@ -12,7 +12,8 @@ use crate::instance::Instance;
 /// ```rust, no_run
 /// # use hyprland::event_listener;
 /// # use hyprland_macros::async_closure;
-/// async fn function() -> std::io::Result<()> {
+/// #[tokio::main(flavor = "current_thread")]
+/// async fn function() -> hyprland::Result<()> {
 ///     let mut listener = event_listener::AsyncEventListener::new();
 ///     listener.add_workspace_changed_handler(async_closure! { |id| println!("workspace changed to {id:?}") });
 ///     listener.start_listener_async().await?;
@@ -48,7 +49,8 @@ impl AsyncEventListener {
     /// ```rust, no_run
     /// # use hyprland::event_listener;
     /// # use hyprland_macros::async_closure;
-    /// async fn function() -> std::io::Result<()> {
+    /// #[tokio::main(flavor = "current_thread")]
+    /// async fn function() -> hyprland::Result<()> {
     ///     let mut listener = event_listener::AsyncEventListener::new();
     ///     listener.add_workspace_changed_handler(async_closure! { |id| println!("workspace changed to {id:?}") });
     ///     listener.start_listener_async().await?;
@@ -64,9 +66,10 @@ impl AsyncEventListener {
     ///
     /// This should be ran after all of your handlers are defined
     /// ```rust, no_run
-    /// # use hyprland::{default_instance_panic, event_listener};
+    /// # use hyprland::{default_instance, event_listener};
     /// # use hyprland_macros::async_closure;
-    /// async fn function() -> std::io::Result<()> {
+    /// #[tokio::main(flavor = "current_thread")]
+    /// async fn function() -> hyprland::Result<()> {
     ///     let mut listener = event_listener::AsyncEventListener::new();
     ///     listener.add_workspace_changed_handler(async_closure! { |id| println!("workspace changed to {id:?}") });
     ///     let instance = default_instance()?;

--- a/src/event_listener/immutable.rs
+++ b/src/event_listener/immutable.rs
@@ -12,7 +12,8 @@ use crate::instance::Instance;
 /// ```rust, no_run
 /// # use hyprland::event_listener;
 /// # use hyprland_macros::async_closure;
-/// async fn function() -> std::io::Result<()> {
+/// #[tokio::main(flavor = "current_thread")]
+/// async fn function() -> hyprland::Result<()> {
 ///     let mut listener = event_listener::EventListener::new();
 ///     listener.add_workspace_changed_handler(|data| println!("{:#?}", data));
 ///     listener.start_listener_async().await?;
@@ -48,7 +49,8 @@ impl EventListener {
     /// ```rust, no_run
     /// # use hyprland::event_listener;
     /// # use hyprland_macros::async_closure;
-    /// async fn function() -> std::io::Result<()> {
+    /// #[tokio::main(flavor = "current_thread")]
+    /// async fn function() -> hyprland::Result<()> {
     ///     let mut listener = event_listener::EventListener::new();
     ///     listener.add_workspace_changed_handler(|data| println!("{:#?}", data));
     ///     listener.start_listener_async().await?;
@@ -65,9 +67,10 @@ impl EventListener {
     ///
     /// This should be ran after all of your handlers are defined
     /// ```rust, no_run
-    /// # use hyprland::{default_instance_panic, event_listener};
+    /// # use hyprland::{default_instance, event_listener};
     /// # use hyprland_macros::async_closure;
-    /// async fn function() -> std::io::Result<()> {
+    /// #[tokio::main(flavor = "current_thread")]
+    /// async fn function() -> hyprland::Result<()> {
     ///     let mut listener = event_listener::EventListener::new();
     ///     listener.add_workspace_changed_handler(|data| println!("{:#?}", data));
     ///     let instance = default_instance()?;
@@ -107,7 +110,7 @@ impl EventListener {
     /// ```rust, no_run
     /// # use hyprland::{default_instance_panic, event_listener};
     /// # use hyprland_macros::async_closure;
-    /// async fn function() -> std::io::Result<()> {
+    /// fn function() -> hyprland::Result<()> {
     ///     let mut listener = event_listener::EventListener::new();
     ///     listener.add_workspace_changed_handler(|data| println!("{:#?}", data));
     ///     listener.start_listener()?;
@@ -122,9 +125,9 @@ impl EventListener {
     ///
     /// This should be ran after all of your handlers are defined
     /// ```rust, no_run
-    /// # use hyprland::{default_instance_panic, event_listener};
+    /// # use hyprland::{default_instance, event_listener};
     /// # use hyprland_macros::async_closure;
-    /// async fn function() -> std::io::Result<()> {
+    /// fn function() -> hyprland::Result<()> {
     ///     let mut listener = event_listener::EventListener::new();
     ///     listener.add_workspace_changed_handler(|data| println!("{:#?}", data));
     ///     let instance = default_instance()?;

--- a/src/event_listener/stream.rs
+++ b/src/event_listener/stream.rs
@@ -18,7 +18,7 @@ use futures_lite::{Stream, StreamExt};
 /// use hyprland::event_listener::EventStream;
 /// use hyprland::Result as HResult;
 ///
-/// #[tokio::main]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() -> HResult<()> {
 ///     use futures_lite::StreamExt;
 ///     use hyprland::instance::Instance;
@@ -26,6 +26,7 @@ use futures_lite::{Stream, StreamExt};
 ///     while let Some(Ok(event)) = stream.next().await {
 ///          println!("{event:?}");
 ///     }
+///     Ok(())
 /// }
 /// ```
 #[must_use = "streams nothing unless polled"]

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -1,5 +1,5 @@
 use crate::error::hypr_err;
-use crate::shared::{get_hypr_path, CommandContent};
+use crate::shared::{CommandContent, get_hypr_path};
 use std::path::{Path, PathBuf};
 
 /// This is the sync version of the Hyprland Instance.


### PR DESCRIPTION
- Fix doc test examples with correct API signatures and return types
- Add Tokio runtime config for async examples
- Use slice syntax for macro arguments
- Elide needless lifetimes in impl blocks
- Import missing types in doc tests