### PR TITLE
update outdated HACK comments in WorkspaceRuleset

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -698,8 +698,13 @@ impl HyprData for Animations {
     }
 }
 
-// HACK: shadow and decorate are actually missing from the hyprctl json output for some reason
-// HACK: gaps_in and gaps_out are returned as arrays with 4 integers, even though Hyprland doesn't support per-side gaps
+// NOTE: shadow and decorate fields may not appear in hyprctl workspacerules output
+// if not explicitly set in workspace rules (they are optional bool fields).
+// Hyprland supports these via: workspace=name:foo,shadow:false,decorate:false
+//
+// NOTE: gaps_in and gaps_out are arrays of 4 integers [top,right,bottom,left] since
+// Hyprland added CSS-style per-side gaps support (PR #4723). The gaps output format
+// changed from single integer to array of 4 integers.
 /// The rules of an individual workspace, as returned by hyprctl json.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceRuleset {


### PR DESCRIPTION
- Replace HACK comments with NOTEs explaining current behavior
- shadow/decorate fields are optional and may not appear in JSON if not set
- gaps_in/gaps_out arrays of 4 integers are correct (per-side gaps now
  supported via CSS syntax since Hyprland PR [#4723](https://github.com/hyprwm/Hyprland/pull/4723))