### PR TITLE
tests: add UTF-8 resilience and type serialization coverage

### DIFF
--- a/src/event_listener/shared.rs
+++ b/src/event_listener/shared.rs
@@ -968,3 +968,38 @@ pub(crate) fn event_parser(event: &str) -> crate::Result<Vec<Event>> {
 
     Ok(events)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Note: `event_parser` takes `&str` which is guaranteed valid UTF-8 in Rust.
+    // Non-UTF8 bytes are handled at the IPC reading level (stream.rs, async_im.rs, immutable.rs)
+    // via `String::from_utf8_lossy()`, which replaces invalid bytes with U+FFFD.
+
+    #[test]
+    fn test_unicode_in_event_args() -> crate::Result<()> {
+        // Test various Unicode characters in event arguments
+        // Emoji in workspace name
+        let events = event_parser("workspace>>rocket🚀space")?;
+        assert_eq!(events.len(), 1);
+
+        // Non-Latin scripts
+        let events = event_parser("workspace>>工作区")?;
+        assert_eq!(events.len(), 1);
+
+        // Mixed ASCII and Unicode
+        let events = event_parser("workspace>>my-über-workspace")?;
+        assert_eq!(events.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_replacement_char_handling() -> crate::Result<()> {
+        // Simulate what happens when from_utf8_lossy replaces invalid bytes with U+FFFD
+        let events = event_parser("workspace>>test�name")?;
+        assert_eq!(events.len(), 1);
+        Ok(())
+    }
+}

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -156,3 +156,49 @@ fn get_env_name() -> crate::Result<String> {
     };
     Ok(instance)
 }
+
+#[cfg(test)]
+mod tests {
+
+    /// Test that from_utf8_lossy handles non-UTF-8 bytes correctly.
+    /// This is the fix from PR #379 - non-UTF-8 bytes (like Windows-1252 encoded
+    /// characters) should be replaced with U+FFFD, not cause an error.
+    #[test]
+    fn test_from_utf8_lossy_handles_invalid_bytes() {
+        // Simulate bytes that might come from a Windows-1252 encoded window title
+        // The ® character in Windows-1252 is byte 0xAE, which is invalid in UTF-8
+        let bytes_with_invalid_utf8: Vec<u8> = vec![
+            0x46, 0x61, 0x72, 0x43, 0x72, 0x79, // "FarCry"
+            0xAE, // Windows-1252 ® (invalid in UTF-8)
+            0x36, // "6"
+        ];
+
+        // This should NOT error - it should replace invalid bytes with U+FFFD
+        let result = String::from_utf8_lossy(&bytes_with_invalid_utf8);
+        let string = result.to_string();
+
+        // The string should contain "FarCry" and "6"
+        assert!(string.contains("FarCry"));
+        assert!(string.contains("6"));
+        // The invalid byte should be replaced with � (U+FFFD)
+        assert!(string.contains('�'));
+    }
+
+    /// Test that the write_to_socket error handling works with the lossy conversion.
+    /// Since we can't easily mock a UnixSocket, we test the conversion directly.
+    #[test]
+    fn test_response_conversion_is_lossy() {
+        // Test with various invalid UTF-8 sequences
+        let test_cases: Vec<Vec<u8>> = vec![
+            vec![0x48, 0x65, 0x6C, 0x6C, 0x6F, 0xAE], // "Hello" + invalid byte
+            vec![0xC0, 0x80],                         // Invalid UTF-8 sequence
+            vec![0xED, 0xA0, 0x80],                   // Surrogate half
+        ];
+
+        for bytes in test_cases {
+            // This should never panic or error
+            let result = String::from_utf8_lossy(&bytes);
+            let _string = result.to_string(); // Should always succeed
+        }
+    }
+}

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -271,3 +271,96 @@ pub enum Mod {
     #[display("")]
     NONE,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_address_new_and_display() {
+        let addr = Address::new("0x123abc");
+        assert_eq!(addr.to_string(), "0x123abc");
+    }
+
+    #[test]
+    fn test_address_from_string() {
+        let addr = Address("0x456def".to_string());
+        assert_eq!(addr.to_string(), "0x456def");
+    }
+
+    #[test]
+    fn test_workspace_type_regular() -> Result<(), Box<dyn std::error::Error>> {
+        let wt = WorkspaceType::Regular("myworkspace".to_string());
+        assert_eq!(wt.to_string(), "myworkspace");
+
+        // Test Serialize
+        let json = serde_json::to_string(&wt)?;
+        assert_eq!(json, "\"myworkspace\"");
+
+        // Test Deserialize
+        let wt2: WorkspaceType = serde_json::from_str("\"myworkspace\"")?;
+        assert_eq!(wt, wt2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_workspace_type_special_with_name() {
+        let wt = WorkspaceType::Special(Some("scratchpad".to_string()));
+        assert_eq!(wt.to_string(), "special:scratchpad");
+    }
+
+    #[test]
+    fn test_workspace_type_special_without_name() {
+        let wt = WorkspaceType::Special(None);
+        assert_eq!(wt.to_string(), "special");
+    }
+
+    #[test]
+    fn test_workspace_type_try_from_int() -> Result<(), Box<dyn std::error::Error>> {
+        let wt: WorkspaceType = 42u32.try_into()?;
+        assert_eq!(wt.to_string(), "42");
+
+        let result: Result<WorkspaceType, _> = 0u32.try_into();
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_command_content_as_bytes() {
+        let content = CommandContent {
+            flag: CommandFlag::JSON,
+            data: "test".to_string(),
+        };
+        assert_eq!(content.as_bytes(), b"j/test");
+
+        let content = CommandContent {
+            flag: CommandFlag::Empty,
+            data: "foo".to_string(),
+        };
+        assert_eq!(content.as_bytes(), b"/foo");
+    }
+
+    #[test]
+    fn test_mod_display() {
+        assert_eq!(Mod::SUPER.to_string(), "SUPER");
+        assert_eq!(Mod::SHIFT.to_string(), "SHIFT");
+        assert_eq!(Mod::ALT.to_string(), "ALT");
+        assert_eq!(Mod::CTRL.to_string(), "CTRL");
+        assert_eq!(Mod::NONE.to_string(), "");
+    }
+
+    #[test]
+    fn test_workspace_id_type() {
+        // WorkspaceId is i32
+        let id: WorkspaceId = 42;
+        assert_eq!(id, 42);
+    }
+
+    #[test]
+    fn test_monitor_id_type() {
+        // MonitorId is i128
+        let id: MonitorId = 12345678901234567890i128;
+        assert_eq!(id, 12345678901234567890i128);
+    }
+}


### PR DESCRIPTION
Add tests for lossy UTF-8 conversion in instance handling and comprehensive
tests for shared type serialization including address, workspace, and mod
display formatting.