### PR TITLE
refactor(hyprpaper): extract response processing and add keyword tests

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -446,6 +446,36 @@ pub mod binds {
             )
         };
     }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::shared::Mod;
+
+        #[test]
+        fn test_vec_mod_join() {
+            let mods = vec![Mod::SUPER, Mod::SHIFT, Mod::CTRL];
+            assert_eq!(mods.join(), "SUPERSHIFTCTRL");
+        }
+
+        #[test]
+        fn test_vec_flag_join() {
+            let flags = vec![Flag::l, Flag::r, Flag::m];
+            assert_eq!(flags.join(), "lrm");
+        }
+
+        #[test]
+        fn test_slice_flag_join() {
+            let flags: &[Flag] = &[Flag::n, Flag::t, Flag::i];
+            assert_eq!(flags.join(), "nti");
+        }
+
+        #[test]
+        fn test_vec_flag_join_empty() {
+            let flags: Vec<Flag> = vec![];
+            assert_eq!(flags.join(), "");
+        }
+    }
 }
 
 #[test]
@@ -462,4 +492,86 @@ fn test_binds() {
         Err(e) => panic!("Error occured: {e}"), // Note to greppers: this is in a test!
     };
     assert_eq!(built_bind, "SUPER,v,togglefloating");
+}
+
+#[test]
+fn test_key_mod_display() {
+    use binds::*;
+    let key = Key::Mod(&[Mod::SUPER, Mod::SHIFT], "V");
+    assert_eq!(key.to_string(), "SUPERSHIFT_V");
+}
+
+#[test]
+fn test_partial_bind() {
+    use binds::*;
+    let partial = PartialBind {
+        mods: &[Mod::SUPER],
+        key: Key::Key("v"),
+    };
+    let result = Binder::gen_str_partial(partial);
+    assert_eq!(result, "SUPER,v");
+}
+
+#[test]
+fn test_binding_with_flags() -> crate::Result<()> {
+    use binds::*;
+    let binding = Binding {
+        mods: &[Mod::SUPER, Mod::SHIFT],
+        key: Key::Key("v"),
+        flags: &[Flag::l, Flag::r],
+        dispatcher: DispatchType::ToggleFloating(None),
+    };
+    let result = Binder::gen_str(binding)?;
+    assert!(result.contains("SUPERSHIFT,v"));
+    assert!(result.contains("togglefloating"));
+    Ok(())
+}
+
+#[test]
+fn test_key_mod_with_multiple_mods() {
+    use binds::*;
+    let key = Key::Mod(&[Mod::SUPER, Mod::CTRL, Mod::ALT], "Return");
+    let result = key.to_string();
+    assert_eq!(result, "SUPERCTRLALT_Return");
+}
+
+#[test]
+fn test_flag_display() {
+    use binds::Flag;
+    assert_eq!(Flag::l.to_string(), "l");
+    assert_eq!(Flag::r.to_string(), "r");
+    assert_eq!(Flag::e.to_string(), "e");
+    assert_eq!(Flag::n.to_string(), "n");
+    assert_eq!(Flag::m.to_string(), "m");
+    assert_eq!(Flag::t.to_string(), "t");
+    assert_eq!(Flag::i.to_string(), "i");
+    assert_eq!(Flag::s.to_string(), "s");
+    assert_eq!(Flag::d.to_string(), "d");
+    assert_eq!(Flag::p.to_string(), "p");
+}
+
+#[test]
+fn test_binding_with_all_flag_types() -> crate::Result<()> {
+    use binds::*;
+    let binding = Binding {
+        mods: &[Mod::SUPER],
+        key: Key::Key("a"),
+        flags: &[
+            Flag::l,
+            Flag::r,
+            Flag::e,
+            Flag::n,
+            Flag::m,
+            Flag::t,
+            Flag::i,
+            Flag::s,
+            Flag::d,
+            Flag::p,
+        ],
+        dispatcher: DispatchType::ToggleFloating(None),
+    };
+    let result = Binder::gen_str(binding)?;
+    assert!(result.contains("SUPER,a"));
+    assert!(result.contains("togglefloating"));
+    Ok(())
 }

--- a/src/hyprpaper.rs
+++ b/src/hyprpaper.rs
@@ -38,16 +38,17 @@ pub fn hyprpaper(keyword: Keyword) -> crate::Result<Response> {
 
 /// Send a keyword to hyprpaper using IPC.
 pub fn instance_hyprpaper(instance: &Instance, keyword: Keyword) -> crate::Result<Response> {
-    let expected_response = keyword.expected_response();
-
     let content = CommandContent {
         flag: crate::shared::CommandFlag::Empty,
         data: keyword.to_string(),
     };
-
     let response = instance.write_to_hyprpaper_socket(content)?;
+    process_hyprpaper_response(keyword, response)
+}
 
-    expected_response.is_expected(response)
+/// Process a hyprpaper response (testable without socket).
+fn process_hyprpaper_response(keyword: Keyword, response: String) -> crate::Result<Response> {
+    keyword.expected_response().is_expected(response)
 }
 
 /// Send a keyword to hyprpaper using IPC.
@@ -60,12 +61,47 @@ pub async fn instance_hyprpaper_async(
     instance: &Instance,
     keyword: Keyword,
 ) -> crate::Result<Response> {
-    let expected_response = keyword.expected_response();
-
     let content = CommandContent {
         flag: crate::shared::CommandFlag::Empty,
         data: keyword.to_string(),
     };
     let response = instance.write_to_hyprpaper_socket_async(content).await?;
-    expected_response.is_expected(response)
+    process_hyprpaper_response(keyword, response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_hyprpaper_response_ok() {
+        let keyword = Keyword::Preload(Preload {
+            path: "/foo".into(),
+        });
+        let result = process_hyprpaper_response(keyword, "ok".into());
+        assert!(matches!(result, Ok(Response::Ok)));
+    }
+
+    #[test]
+    fn test_process_hyprpaper_response_active() {
+        let keyword = Keyword::ListActive;
+        let result = process_hyprpaper_response(keyword, "DP-1 = /wallpaper.png".into());
+        assert!(matches!(result, Ok(Response::ActiveWallpapers(_))));
+    }
+
+    #[test]
+    fn test_process_hyprpaper_response_loaded() {
+        let keyword = Keyword::ListLoaded;
+        let result = process_hyprpaper_response(keyword, "/wallpaper.png".into());
+        assert!(matches!(result, Ok(Response::LoadedWallpapers(_))));
+    }
+
+    #[test]
+    fn test_process_hyprpaper_response_not_ok() {
+        let keyword = Keyword::Preload(Preload {
+            path: "/foo".into(),
+        });
+        let result = process_hyprpaper_response(keyword, "error".into());
+        assert!(result.is_err());
+    }
 }

--- a/src/hyprpaper/keyword.rs
+++ b/src/hyprpaper/keyword.rs
@@ -144,4 +144,86 @@ mod tests {
         let command = Keyword::Unload(Unload::All);
         check(command, "unload all");
     }
+
+    #[test]
+    fn test_reload() {
+        let command = Keyword::Reload(Reload {
+            monitor: None,
+            mode: None,
+            path: "/foo/bar".into(),
+        });
+        check(command, "reload ,/foo/bar");
+
+        let command = Keyword::Reload(Reload {
+            monitor: Some(Monitor::Port("DP-1".into())),
+            mode: None,
+            path: "/foo/bar".into(),
+        });
+        check(command, "reload DP-1,/foo/bar");
+
+        let command = Keyword::Reload(Reload {
+            monitor: Some(Monitor::Description("main".into())),
+            mode: Some(WallpaperMode::Contain),
+            path: "/wallpaper.png".into(),
+        });
+        check(command, "reload desc:main,contain:/wallpaper.png");
+    }
+
+    #[test]
+    fn test_list_active() {
+        let command = Keyword::ListActive;
+        check(command, "listactive");
+    }
+
+    #[test]
+    fn test_list_loaded() {
+        let command = Keyword::ListLoaded;
+        check(command, "listloaded");
+    }
+
+    #[test]
+    fn test_expected_response() {
+        use super::ExpectedResponse;
+
+        assert!(matches!(Keyword::Preload(Preload { path: "".into() }).expected_response(), ExpectedResponse::Ok));
+        assert!(matches!(Keyword::Reload(Reload { monitor: None, mode: None, path: "".into() }).expected_response(), ExpectedResponse::Ok));
+        assert!(matches!(Keyword::Unload(Unload::All).expected_response(), ExpectedResponse::Ok));
+        assert!(matches!(Keyword::Wallpaper(Wallpaper { monitor: None, mode: None, path: "".into() }).expected_response(), ExpectedResponse::Ok));
+        assert!(matches!(Keyword::ListActive.expected_response(), ExpectedResponse::Active));
+        assert!(matches!(Keyword::ListLoaded.expected_response(), ExpectedResponse::Loaded));
+    }
+
+    #[test]
+    fn test_expected_response_ok() {
+        use super::ExpectedResponse;
+
+        let expected = ExpectedResponse::Ok;
+        assert!(matches!(expected.is_expected("ok".into()), Ok(Response::Ok)));
+        assert!(matches!(expected.is_expected(" ok ".into()), Ok(Response::Ok)));
+        assert!(expected.is_expected("error".into()).is_err());
+    }
+
+    #[test]
+    fn test_expected_response_active() {
+        use super::ExpectedResponse;
+
+        let expected = ExpectedResponse::Active;
+        assert!(matches!(
+            expected.is_expected("DP-1 = /path/to/wallpaper.png".into()),
+            Ok(Response::ActiveWallpapers(_))
+        ));
+        assert!(expected.is_expected("no wallpapers active".into()).is_err());
+    }
+
+    #[test]
+    fn test_expected_response_loaded() {
+        use super::ExpectedResponse;
+
+        let expected = ExpectedResponse::Loaded;
+        assert!(matches!(
+            expected.is_expected("/path/to/wallpaper.png".into()),
+            Ok(Response::LoadedWallpapers(_))
+        ));
+        assert!(expected.is_expected("no wallpapers loaded".into()).is_err());
+    }
 }

--- a/src/hyprpaper/keyword.rs
+++ b/src/hyprpaper/keyword.rs
@@ -185,12 +185,40 @@ mod tests {
     fn test_expected_response() {
         use super::ExpectedResponse;
 
-        assert!(matches!(Keyword::Preload(Preload { path: "".into() }).expected_response(), ExpectedResponse::Ok));
-        assert!(matches!(Keyword::Reload(Reload { monitor: None, mode: None, path: "".into() }).expected_response(), ExpectedResponse::Ok));
-        assert!(matches!(Keyword::Unload(Unload::All).expected_response(), ExpectedResponse::Ok));
-        assert!(matches!(Keyword::Wallpaper(Wallpaper { monitor: None, mode: None, path: "".into() }).expected_response(), ExpectedResponse::Ok));
-        assert!(matches!(Keyword::ListActive.expected_response(), ExpectedResponse::Active));
-        assert!(matches!(Keyword::ListLoaded.expected_response(), ExpectedResponse::Loaded));
+        assert!(matches!(
+            Keyword::Preload(Preload { path: "".into() }).expected_response(),
+            ExpectedResponse::Ok
+        ));
+        assert!(matches!(
+            Keyword::Reload(Reload {
+                monitor: None,
+                mode: None,
+                path: "".into()
+            })
+            .expected_response(),
+            ExpectedResponse::Ok
+        ));
+        assert!(matches!(
+            Keyword::Unload(Unload::All).expected_response(),
+            ExpectedResponse::Ok
+        ));
+        assert!(matches!(
+            Keyword::Wallpaper(Wallpaper {
+                monitor: None,
+                mode: None,
+                path: "".into()
+            })
+            .expected_response(),
+            ExpectedResponse::Ok
+        ));
+        assert!(matches!(
+            Keyword::ListActive.expected_response(),
+            ExpectedResponse::Active
+        ));
+        assert!(matches!(
+            Keyword::ListLoaded.expected_response(),
+            ExpectedResponse::Loaded
+        ));
     }
 
     #[test]
@@ -198,8 +226,14 @@ mod tests {
         use super::ExpectedResponse;
 
         let expected = ExpectedResponse::Ok;
-        assert!(matches!(expected.is_expected("ok".into()), Ok(Response::Ok)));
-        assert!(matches!(expected.is_expected(" ok ".into()), Ok(Response::Ok)));
+        assert!(matches!(
+            expected.is_expected("ok".into()),
+            Ok(Response::Ok)
+        ));
+        assert!(matches!(
+            expected.is_expected(" ok ".into()),
+            Ok(Response::Ok)
+        ));
         assert!(expected.is_expected("error".into()).is_err());
     }
 


### PR DESCRIPTION
Refactor synchronous and asynchronous hyprpaper dispatch to delegate to a new testable function. Introduce unit tests for keyword response expectation logic covering all major keyword variants.

The core response processing logic is now covered. The socket I/O functions remain uncovered as they require actual hyprpaper connections.