### PR TITLE
client: add visible field

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -260,6 +260,8 @@ pub struct Client {
     pub grouped: Vec<Box<Address>>,
     /// Is this window print on screen
     pub mapped: bool,
+    /// Is this window visible on screen
+    pub visible: bool,
     /// The swallowed window
     pub swallowing: Option<Box<Address>>,
     /// When was this window last focused relatively to other windows? 0 for current, 1 previous, 2 previous before that, etc


### PR DESCRIPTION
This seems to be the only way to tell which window is visible in a group, no other fields are different between the active client in a group and the inactive ones.

`hyprctl clients -j` shows this for two windows in a group. Tested against Hyprland 0.55.2.

```
{
    "address": "0x5631a8907ae0",
    "mapped": true,
    "hidden": false,
    "visible": true,
    "acceptsInput": true,
    "at": [2581, 2172],
    "size": [2518, 657],
    "workspace": {
        "id": 5,
        "name": "5"
    },
    "floating": false,
    "monitor": 1,
    "class": "foot",
    "title": "foot",
    "initialClass": "foot",
    "initialTitle": "foot",
    "pid": 1206301,
    "xwayland": false,
    "pinned": false,
    "fullscreen": 0,
    "fullscreenClient": 0,
    "overFullscreen": false,
    "grouped": ["0x5631a8907ae0", "0x5631a8920250"],
    "tags": [],
    "swallowing": "0x0",
    "focusHistoryID": 1,
    "inhibitingIdle": false,
    "xdgTag": "",
    "xdgDescription": "",
    "contentType": "none",
    "stableId": "18000019"
},{
    "address": "0x5631a8920250",
    "mapped": true,
    "hidden": false,
    "visible": false,
    "acceptsInput": false,
    "at": [2581, 2172],
    "size": [2518, 657],
    "workspace": {
        "id": 5,
        "name": "5"
    },
    "floating": false,
    "monitor": 1,
    "class": "BoltLauncher",
    "title": "Bolt Launcher",
    "initialClass": "BoltLauncher",
    "initialTitle": "Bolt Launcher",
    "pid": 1204262,
    "xwayland": false,
    "pinned": false,
    "fullscreen": 0,
    "fullscreenClient": 0,
    "overFullscreen": true,
    "grouped": ["0x5631a8907ae0", "0x5631a8920250"],
    "tags": [],
    "swallowing": "0x0",
    "focusHistoryID": 2,
    "inhibitingIdle": false,
    "xdgTag": "",
    "xdgDescription": "",
    "contentType": "none",
    "stableId": "18000018"
},
```