### PR TITLE
feat(layerclient): add `PID` field to `LayerClient`

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -329,6 +329,8 @@ pub struct LayerClient {
     pub h: i16,
     /// The layer's namespace
     pub namespace: String,
+    /// The process Id of the layer
+    pub pid: i32,
 }
 
 /// This struct holds all the layer surfaces for a display


### PR DESCRIPTION
Closes #392.

Since `hyprctl layers` already exposes the `pid` field for layers, this PR simply adds the ability to access it. 