### PR TITLE
decode IPC responses with non-UTF-8 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +227,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "errno"
@@ -304,8 +324,10 @@ dependencies = [
  "ahash",
  "async-net",
  "async-stream",
+ "chardetng",
  "derive_more",
  "either",
+ "encoding_rs",
  "futures-lite",
  "hyprland-macros",
  "pastey",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ ahash = { version = "0.8.12", features = [
 ], optional = true, default-features = false }
 either = "1.15.0"
 async-stream = "0.3.6"
+chardetng = "0.1"
+encoding_rs = "0.8"
 
 [features]
 default = [

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1,0 +1,42 @@
+//! Encoding detection for byte streams that come back from the Hyprland IPC.
+//!
+//! Hyprland stores window titles verbatim — whatever bytes the X11/Wayland
+//! client set via `_NET_WM_NAME` or `xdg_toplevel::set_title`. Some clients
+//! (notably OnlyOffice and Java/Swing apps like Jubler) use a non-UTF-8
+//! encoding (typically the JVM's default charset or Latin-1) and so the
+//! title contains bytes that are not valid UTF-8.
+//!
+//! Naively calling `String::from_utf8_lossy` would replace every invalid byte
+//! with U+FFFD and destroy the actual content (e.g. `tradu��ocoletiva.docx`
+//! instead of `traduçãocoletiva.docx`).
+//!
+//! This module detects the most likely encoding of the byte stream using
+//! `chardetng` (the same library Firefox uses) and decodes with
+//! `encoding_rs`. If detection fails or the stream is ambiguous, we fall
+//! back to UTF-8 lossy — same behavior as before, no regression.
+
+use chardetng::EncodingDetector;
+
+/// Decode arbitrary bytes as a string, trying to detect the encoding.
+///
+/// Behavior:
+/// 1. If the bytes are valid UTF-8, return them as-is (no detection overhead).
+/// 2. Otherwise, run `chardetng` to guess the encoding, then decode with
+///    `encoding_rs`. Any remaining invalid bytes are replaced with U+FFFD.
+/// 3. As a last resort, return `String::from_utf8_lossy(bytes)` (same as the
+///    pre-fix behavior — better than crashing or panicking).
+pub fn decode_ipc_response(bytes: &[u8]) -> String {
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        return s.to_owned();
+    }
+    let mut det = EncodingDetector::new();
+    det.feed(bytes, true);
+    let enc = det.guess(None, true);
+    let (decoded, _, _) = enc.decode(bytes);
+    if decoded.contains('\u{FFFD}') {
+        // Detection was wrong / ambiguous — fall back to lossy UTF-8 so the
+        // caller at least gets the same behavior as before this fix.
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    decoded.into_owned()
+}

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -69,7 +69,7 @@ impl Instance {
         stream.write_all(&content.as_bytes())?;
         let mut response = Vec::new();
         stream.read_to_end(&mut response)?;
-        Ok(String::from_utf8_lossy(&response).to_string())
+        Ok(crate::encoding::decode_ipc_response(&response))
     }
 
     #[cfg(any(feature = "async-lite", feature = "tokio"))]
@@ -82,7 +82,7 @@ impl Instance {
         stream.write_all(&content.as_bytes()).await?;
         let mut response = Vec::new();
         stream.read_to_end(&mut response).await?;
-        Ok(String::from_utf8_lossy(&response).to_string())
+        Ok(crate::encoding::decode_ipc_response(&response))
     }
 
     #[cfg(feature = "hyprpaper")]
@@ -104,7 +104,7 @@ impl Instance {
                 break;
             }
         }
-        Ok(String::from_utf8_lossy(&response).to_string())
+        Ok(crate::encoding::decode_ipc_response(&response))
     }
 
     #[cfg(all(feature = "hyprpaper", any(feature = "async-lite", feature = "tokio")))]
@@ -126,7 +126,7 @@ impl Instance {
                 break;
             }
         }
-        Ok(String::from_utf8_lossy(&response).to_string())
+        Ok(crate::encoding::decode_ipc_response(&response))
     }
 
     #[cfg(feature = "listener")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,10 @@ pub mod config;
 
 /// Holds the error type used throughout the crate
 pub mod error;
+
+/// Encoding helpers used internally by the crate
+mod encoding;
+
 /// Used to generate the Instances to interface with Hyprland
 pub mod instance;
 


### PR DESCRIPTION
Hyprland stores window titles verbatim. Clients like OnlyOffice and
Java/Swing apps (Jubler) may set the title with non-UTF-8 bytes (raw
filename bytes in the JVM's default charset or Latin-1), which produced
`tradu��ocoletiva.docx` instead of `traduçãocoletiva.docx` in downstream
tools that decoded the response with `String::from_utf8_lossy`.

Replace the lossy UTF-8 decode in `Instance::write_to_socket[_async]`
(and the hyprpaper variants) with a content-based encoding detector
(chardetng + encoding_rs). Valid UTF-8 still passes through untouched;
ambiguous bytes fall back to lossy (no regression vs. before).



Related to https://github.com/MalpenZibo/ashell/issues/577