### PR TITLE
add serde default to new v0.55 fields for backward compat

### DIFF
--- a/src/data/regular.rs
+++ b/src/data/regular.rs
@@ -181,10 +181,10 @@ pub struct Workspace {
     #[serde(rename = "lastwindowtitle")]
     pub last_window_title: String,
     /// Is this workspace persistent?
-    #[serde(rename = "ispersistent")]
+    #[serde(default, rename = "ispersistent")]
     pub persistent: bool,
     /// The workspace's layout
-    #[serde(rename = "tiledLayout")]
+    #[serde(default, rename = "tiledLayout")]
     pub tiled_layout: String,
 }
 
@@ -248,10 +248,11 @@ pub struct Client {
     /// Is this window printed on screen?
     pub mapped: bool,
     /// Is this window hidden?
+    #[serde(default)]
     pub hidden: bool,
     /// Is this window visible on screen?
     pub visible: bool,
-    #[serde(rename = "acceptsInput")]
+    #[serde(default, rename = "acceptsInput")]
     /// Does this window accept input?
     pub accepts_input: bool,
     /// The window location
@@ -286,11 +287,12 @@ pub struct Client {
     #[serde(rename = "fullscreenClient")]
     pub fullscreen_client: FullscreenMode,
     /// Whether the window was created over a fullscreen window
-    #[serde(rename = "overFullscreen")]
+    #[serde(default, rename = "overFullscreen")]
     pub over_fullscreen: bool,
     /// Group members
     pub grouped: Vec<Box<Address>>,
     /// Tags
+    #[serde(default)]
     pub tags: Vec<String>,
     /// The swallowed window
     pub swallowing: Option<Box<Address>>,
@@ -298,19 +300,19 @@ pub struct Client {
     #[serde(rename = "focusHistoryID")]
     pub focus_history_id: i8,
     /// Is the window inibiting idle
-    #[serde(rename = "inhibitingIdle")]
+    #[serde(default, rename = "inhibitingIdle")]
     pub inhibiting_idle: bool,
     /// The XDG tag for the Window
-    #[serde(rename = "xdgTag")]
+    #[serde(default, rename = "xdgTag")]
     pub xdg_tag: String,
     /// The XDG description for the Window
-    #[serde(rename = "xdgDescription")]
+    #[serde(default, rename = "xdgDescription")]
     pub xdg_description: String,
     /// The content type of the window
-    #[serde(rename = "contentType")]
+    #[serde(default, rename = "contentType")]
     pub content_type: String,
     /// The stable ID of the window for the `ext_foreign_toplevel_list_v1` protocol
-    #[serde(rename = "stableId")]
+    #[serde(default, rename = "stableId")]
     pub stable_id: String,
 }
 


### PR DESCRIPTION
Commit [3960214](https://github.com/hyprland-community/hyprland-rs/commit/3960214) added new fields to Client and Workspace for v0.55 that
were present in the 0.55 IPC output. Hyprland 0.56 dropped these
fields from the JSON output, causing deserialization to fail on every
data query (`Clients::get`, `Workspaces::get`, `Client::get_active`, etc.).

Add `#[serde(default)]` to all 11 affected fields so they fall back to
their type defaults when absent.

bug related to 
https://github.com/MalpenZibo/ashell/issues/885

@yavko  thanks
